### PR TITLE
Keep emitting routes when losing the lock and consul is unhealthy

### DIFF
--- a/cmd/route-emitter/main_suite_test.go
+++ b/cmd/route-emitter/main_suite_test.go
@@ -41,13 +41,14 @@ var (
 	bbsRunner  *ginkgomon.Runner
 	bbsProcess ifrit.Process
 
-	etcdRunner   *etcdstorerunner.ETCDClusterRunner
-	consulRunner *consulrunner.ClusterRunner
-	gnatsdRunner ifrit.Process
-	natsClient   diegonats.NATSClient
-	bbsClient    bbs.InternalClient
-	logger       *lagertest.TestLogger
-	syncInterval time.Duration
+	etcdRunner           *etcdstorerunner.ETCDClusterRunner
+	consulRunner         *consulrunner.ClusterRunner
+	gnatsdRunner         ifrit.Process
+	natsClient           diegonats.NATSClient
+	bbsClient            bbs.InternalClient
+	logger               *lagertest.TestLogger
+	syncInterval         time.Duration
+	consulClusterAddress string
 
 	sqlProcess ifrit.Process
 	sqlRunner  sqlrunner.SQLRunner
@@ -69,7 +70,8 @@ func createEmitterRunner(sessionName string) *ginkgomon.Runner {
 			"-communicationTimeout", "100ms",
 			"-syncInterval", syncInterval.String(),
 			"-lockRetryInterval", "1s",
-			"-consulCluster", consulRunner.ConsulCluster(),
+			"-lockTTL", "5s",
+			"-consulCluster", consulClusterAddress,
 		),
 
 		StartCheck: "route-emitter.watcher.sync.complete",
@@ -157,6 +159,7 @@ var _ = BeforeEach(func() {
 	etcdRunner.Start()
 	consulRunner.Start()
 	consulRunner.WaitUntilReady()
+	consulClusterAddress = consulRunner.ConsulCluster()
 
 	bbsRunner = bbstestrunner.New(bbsPath, bbsArgs)
 	bbsProcess = ginkgomon.Invoke(bbsRunner)

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -338,7 +338,7 @@ var _ = Describe("Route Emitter", func() {
 			})
 		})
 
-		It("emits a metric to say that it is not in paranoid mode", func() {
+		It("emits a metric to say that it is not in consul down mode", func() {
 			type metricAndValue struct {
 				Name  string
 				Value int32
@@ -350,12 +350,12 @@ var _ = Describe("Route Emitter", func() {
 					return metricAndValue{Name: *envelope.ValueMetric.Name, Value: int32(*envelope.ValueMetric.Value)}
 				}
 				return metricAndValue{}
-			}).Should(Equal(metricAndValue{Name: "ParanoidMode", Value: 0}))
+			}).Should(Equal(metricAndValue{Name: "ConsulDownMode", Value: 0}))
 
 		})
 	})
 
-	Describe("paranoid mode", func() {
+	Describe("consul down mode", func() {
 		var (
 			emitter           ifrit.Process
 			runner            *ginkgomon.Runner
@@ -414,22 +414,22 @@ var _ = Describe("Route Emitter", func() {
 				consulRunner.Stop()
 			})
 
-			It("enters paranoid mode and exits when consul comes back up", func() {
+			It("enters consul down mode and exits when consul comes back up", func() {
 				lockTTL := 5
 				retryInterval := 1
-				Eventually(runner, lockTTL+3*retryInterval+1).Should(gbytes.Say("paranoid-mode.started"))
+				Eventually(runner, lockTTL+3*retryInterval+1).Should(gbytes.Say("consul-down-mode.started"))
 				consulRunner.Start()
 				fakeConsulHandler = nil
-				Eventually(runner, 3*retryInterval+1).Should(gbytes.Say("paranoid-mode.exited"))
+				Eventually(runner, 3*retryInterval+1).Should(gbytes.Say("consul-down-mode.exited"))
 				var err error
 				Eventually(emitter.Wait()).Should(Receive(&err))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("emits a metric to say that it has entered paranoid mode", func() {
+			It("emits a metric to say that it has entered consul down mode", func() {
 				lockTTL := 5
 				retryInterval := 1
-				Eventually(runner, lockTTL+3*retryInterval+1).Should(gbytes.Say("paranoid-mode.started"))
+				Eventually(runner, lockTTL+3*retryInterval+1).Should(gbytes.Say("consul-down-mode.started"))
 
 				type metricAndValue struct {
 					Name  string
@@ -442,7 +442,7 @@ var _ = Describe("Route Emitter", func() {
 						return metricAndValue{Name: *envelope.ValueMetric.Name, Value: int32(*envelope.ValueMetric.Value)}
 					}
 					return metricAndValue{}
-				}).Should(Equal(metricAndValue{Name: "ParanoidMode", Value: 1}))
+				}).Should(Equal(metricAndValue{Name: "ConsulDownMode", Value: 1}))
 
 			})
 

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -121,8 +121,8 @@ var _ = Describe("Route Emitter", func() {
 		})
 
 		It("returns 20 second", func() {
-			Expect(runner.Buffer()).To(gbytes.Say("setting-nats-ping-interval"))
-			Expect(runner.Buffer()).To(gbytes.Say(`"duration-in-seconds":20`))
+			Expect(runner).To(gbytes.Say("setting-nats-ping-interval"))
+			Expect(runner).To(gbytes.Say(`"duration-in-seconds":20`))
 		})
 	})
 
@@ -398,10 +398,12 @@ var _ = Describe("Route Emitter", func() {
 			})
 
 			It("enters paranoid mode and exits when consul comes back up", func() {
-				Eventually(runner.Buffer(), 6).Should(gbytes.Say("paranoid-mode.started"))
+				lockTTL := 5
+				retryInterval := 1
+				Eventually(runner, lockTTL+3*retryInterval+1).Should(gbytes.Say("paranoid-mode.started"))
 				consulRunner.Start()
 				fakeConsulHandler = nil
-				Eventually(runner.Buffer()).Should(gbytes.Say("paranoid-mode.exited"))
+				Eventually(runner, 3*retryInterval+1).Should(gbytes.Say("paranoid-mode.exited"))
 				var err error
 				Eventually(emitter.Wait()).Should(Receive(&err))
 				Expect(err).NotTo(HaveOccurred())

--- a/consuldownchecker/consul_down_checker.go
+++ b/consuldownchecker/consul_down_checker.go
@@ -1,0 +1,72 @@
+package consuldownchecker
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/consuladapter"
+	"code.cloudfoundry.org/lager"
+)
+
+type ConsulDownChecker struct {
+	logger        lager.Logger
+	clock         clock.Clock
+	consulClient  consuladapter.Client
+	retryInterval time.Duration
+}
+
+func NewConsulDownChecker(
+	logger lager.Logger,
+	clock clock.Clock,
+	consulClient consuladapter.Client,
+	retryInterval time.Duration,
+) *ConsulDownChecker {
+	return &ConsulDownChecker{
+		logger: logger, clock: clock, consulClient: consulClient, retryInterval: retryInterval,
+	}
+}
+
+func (c *ConsulDownChecker) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	logger := c.logger.Session("consul-down-checker")
+	logger.Info("starting")
+	defer logger.Info("finished")
+	retryTimer := c.clock.NewTimer(0)
+
+	hasLeader, err := c.checkForLeader(logger)
+	if hasLeader || err != nil {
+		return err
+	}
+	close(ready)
+
+	for {
+		select {
+		case <-signals:
+			logger.Info("received-signal")
+			return nil
+		case <-retryTimer.C():
+			hasLeader, err := c.checkForLeader(logger)
+			if hasLeader || err != nil {
+				return err
+			}
+			logger.Info("still-down")
+			retryTimer.Reset(c.retryInterval)
+		}
+	}
+}
+
+func (c *ConsulDownChecker) checkForLeader(logger lager.Logger) (bool, error) {
+	leader, err := c.consulClient.Status().Leader()
+	if err != nil && !strings.Contains(err.Error(), "Unexpected response code: 500") {
+		logger.Error("failed-getting-leader", err)
+		return false, err
+	}
+
+	if leader != "" {
+		logger.Info("consul-has-leader")
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/consuldownchecker/consul_down_checker_test.go
+++ b/consuldownchecker/consul_down_checker_test.go
@@ -1,0 +1,104 @@
+package consuldownchecker_test
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/clock/fakeclock"
+	"code.cloudfoundry.org/consuladapter/fakes"
+	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/route-emitter/consuldownchecker"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("ConsulDownChecker", func() {
+	var (
+		logger        *lagertest.TestLogger
+		clock         *fakeclock.FakeClock
+		consulClient  *fakes.FakeClient
+		statusClient  *fakes.FakeStatus
+		retryInterval time.Duration
+		signals       chan os.Signal
+		ready         chan struct{}
+
+		consulDownChecker *consuldownchecker.ConsulDownChecker
+	)
+
+	BeforeEach(func() {
+		clock = fakeclock.NewFakeClock(time.Now())
+		logger = lagertest.NewTestLogger("test")
+		retryInterval = 100 * time.Millisecond
+		consulClient = new(fakes.FakeClient)
+		statusClient = new(fakes.FakeStatus)
+		consulClient.StatusReturns(statusClient)
+		signals = make(chan os.Signal)
+		ready = make(chan struct{})
+
+		consulDownChecker = consuldownchecker.NewConsulDownChecker(logger, clock, consulClient, retryInterval)
+	})
+
+	It("exits quickly if consul has a leader", func() {
+		statusClient.LeaderReturns("Pompeius", nil)
+		err := consulDownChecker.Run(signals, ready)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).NotTo(BeClosed())
+	})
+
+	It("exits quickly with error if consul agent is unreachable", func() {
+		statusClient.LeaderReturns("", errors.New("not a five hundred"))
+		err := consulDownChecker.Run(signals, ready)
+		Expect(err).To(HaveOccurred())
+		Expect(ready).NotTo(BeClosed())
+	})
+
+	Context("when consul does not have leader", func() {
+		var runErrCh chan error
+
+		BeforeEach(func() {
+			statusClient.LeaderReturns("", errors.New("Unexpected response code: 500 (rpc error: No cluster leader)"))
+			runErrCh = make(chan error)
+
+			go func() {
+				defer GinkgoRecover()
+				runErrCh <- consulDownChecker.Run(signals, ready)
+			}()
+			Eventually(ready).Should(BeClosed())
+		})
+
+		It("continuously checks for the leader", func() {
+			Eventually(logger).Should(gbytes.Say("still-down"))
+			clock.WaitForWatcherAndIncrement(retryInterval)
+			Eventually(logger).Should(gbytes.Say("still-down"))
+		})
+
+		It("exits gracefully when interrupted", func() {
+			signals <- os.Interrupt
+			Eventually(logger).Should(gbytes.Say("received-signal"))
+			var err error
+			Eventually(runErrCh).Should(Receive(&err))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("exits when there is a leader", func() {
+			statusClient.LeaderReturns("Ceasar", nil)
+			clock.WaitForWatcherAndIncrement(retryInterval)
+			Eventually(logger).Should(gbytes.Say("consul-has-leader"))
+			var err error
+			Eventually(runErrCh).Should(Receive(&err))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("exits with error when consul agent is unreachable", func() {
+			statusClient.LeaderReturns("", errors.New("not a five hundred"))
+			clock.WaitForWatcherAndIncrement(retryInterval)
+			Eventually(logger).Should(gbytes.Say("failed-getting-leader"))
+			var err error
+			Eventually(runErrCh).Should(Receive(&err))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/consuldownchecker/consuldownchecker_suite_test.go
+++ b/consuldownchecker/consuldownchecker_suite_test.go
@@ -1,0 +1,13 @@
+package consuldownchecker_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestConsuldownchecker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Consul Down Checker Suite")
+}

--- a/consuldownmodenotifier/consul_down_mode_notifier.go
+++ b/consuldownmodenotifier/consul_down_mode_notifier.go
@@ -1,4 +1,4 @@
-package paranoidmodenotifier
+package consuldownmodenotifier
 
 import (
 	"os"
@@ -9,30 +9,30 @@ import (
 	"code.cloudfoundry.org/runtimeschema/metric"
 )
 
-type ParanoidModeNofitier struct {
+type ConsulDownModeNofitier struct {
 	logger   lager.Logger
 	value    int
 	clock    clock.Clock
 	interval time.Duration
 }
 
-func NewParanoidModeNotifier(
+func NewConsulDownModeNotifier(
 	logger lager.Logger,
 	value int,
 	clock clock.Clock,
 	interval time.Duration,
-) *ParanoidModeNofitier {
-	return &ParanoidModeNofitier{
+) *ConsulDownModeNofitier {
+	return &ConsulDownModeNofitier{
 		logger: logger, value: value, clock: clock, interval: interval,
 	}
 }
 
-func (p *ParanoidModeNofitier) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
-	logger := p.logger.Session("paranoid-mode-notifier")
+func (p *ConsulDownModeNofitier) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	logger := p.logger.Session("consul-down-mode-notifier")
 	logger.Info("starting")
 	defer logger.Info("finished")
 	retryTimer := p.clock.NewTimer(0)
-	var paranoidMetric = metric.Metric("ParanoidMode")
+	var consulDownMetric = metric.Metric("ConsulDownMode")
 
 	close(ready)
 
@@ -42,7 +42,7 @@ func (p *ParanoidModeNofitier) Run(signals <-chan os.Signal, ready chan<- struct
 			logger.Info("received-signal")
 			return nil
 		case <-retryTimer.C():
-			paranoidMetric.Send(p.value)
+			consulDownMetric.Send(p.value)
 			retryTimer.Reset(p.interval)
 		}
 	}

--- a/paranoidmodenotifier/paranoid_mode_notifier.go
+++ b/paranoidmodenotifier/paranoid_mode_notifier.go
@@ -1,0 +1,49 @@
+package paranoidmodenotifier
+
+import (
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/runtimeschema/metric"
+)
+
+type ParanoidModeNofitier struct {
+	logger   lager.Logger
+	value    int
+	clock    clock.Clock
+	interval time.Duration
+}
+
+func NewParanoidModeNotifier(
+	logger lager.Logger,
+	value int,
+	clock clock.Clock,
+	interval time.Duration,
+) *ParanoidModeNofitier {
+	return &ParanoidModeNofitier{
+		logger: logger, value: value, clock: clock, interval: interval,
+	}
+}
+
+func (p *ParanoidModeNofitier) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	logger := p.logger.Session("paranoid-mode-notifier")
+	logger.Info("starting")
+	defer logger.Info("finished")
+	retryTimer := p.clock.NewTimer(0)
+	var paranoidMetric = metric.Metric("ParanoidMode")
+
+	close(ready)
+
+	for {
+		select {
+		case <-signals:
+			logger.Info("received-signal")
+			return nil
+		case <-retryTimer.C():
+			paranoidMetric.Send(p.value)
+			retryTimer.Reset(p.interval)
+		}
+	}
+}


### PR DESCRIPTION
During a CF Deploy (or possibly at other times) `consul` may become unavailable or fail to elect a leader. We probably should not lose app routes during this situation.

The solutions tackles the problem of `consul` being unavailable because of lack of a leader or just down. It enables app routes to stay available in face of a `consul` downtime.

The route-emitter implementation will behave as follows:
- Start
  - Try to get lock from consul (keep trying until successful)
  - Start emitting a metric `ConsulDownMode` every `consulDownModeNotificationInterval` with the value `0`
  - Start synchronizing routing table with BBS
  - Start emitting routes
- Exit (via lost lock or otherwise)
  - Check if consul has a leader
    - If consul has a leader a 3 times in a row: exit
    - Else: start consul down mode
- Consul Down Mode
  - Keep checking if consul has a leader
  - When leader is found and keeps being up 3 times in a row exit consul down mode
  - Start emitting a metric `ConsulDownMode` every `consulDownModeNotificationInterval` with the value `1`
  - Start emitting routes
  - Start synchronizing routing table with BBS (this will likely fail if consul is down, so we’ll use the existing routing table)

Cheers,
@luan and @charleshansen
