### PR TITLE
use the scheduling info domain instead of figuring it out from actual…

### DIFF
--- a/routingtable/endpoint.go
+++ b/routingtable/endpoint.go
@@ -36,7 +36,6 @@ type Endpoint struct {
 	Index            int32
 	Host             string
 	ContainerIP      string
-	Domain           string
 	Port             uint32
 	ContainerPort    uint32
 	Evacuating       bool
@@ -57,13 +56,11 @@ func NewEndpoint(
 	host, containerIP string,
 	port, containerPort uint32,
 	modificationTag *models.ModificationTag,
-	domain string,
 ) Endpoint {
 	return Endpoint{
 		InstanceGUID:    instanceGUID,
 		Evacuating:      evacuating,
 		Host:            host,
-		Domain:          domain,
 		ContainerIP:     containerIP,
 		Port:            port,
 		ContainerPort:   containerPort,
@@ -123,6 +120,7 @@ func (r Route) MessageFor(endpoint Endpoint, directInstanceAddress bool) (*Regis
 
 func (entry RoutableEndpoints) copy() RoutableEndpoints {
 	clone := RoutableEndpoints{
+		Domain:           entry.Domain,
 		Endpoints:        map[EndpointKey]Endpoint{},
 		Routes:           make([]externalRoute, len(entry.Routes)),
 		DesiredInstances: entry.DesiredInstances,
@@ -139,6 +137,7 @@ func (entry RoutableEndpoints) copy() RoutableEndpoints {
 }
 
 type RoutableEndpoints struct {
+	Domain           string
 	Routes           []externalRoute
 	Endpoints        map[EndpointKey]Endpoint
 	DesiredInstances int32
@@ -156,7 +155,6 @@ func NewEndpointsFromActual(actualLRPInfo *ActualLRPRoutingInfo) map[uint32]Endp
 				Index:           actual.Index,
 				Host:            actual.Address,
 				ContainerIP:     actual.InstanceAddress,
-				Domain:          actual.Domain,
 				Port:            portMapping.HostPort,
 				ContainerPort:   portMapping.ContainerPort,
 				Evacuating:      actualLRPInfo.Evacuating,

--- a/routingtable/endpoint_utils_test.go
+++ b/routingtable/endpoint_utils_test.go
@@ -33,8 +33,8 @@ var _ = Describe("LRP Utils", func() {
 				endpoints := routingtable.NewEndpointsFromActual(actualInfo)
 
 				Expect(endpoints).To(ConsistOf([]routingtable.Endpoint{
-					routingtable.NewEndpoint("instance-guid", false, "1.1.1.1", "2.2.2.2", 11, 44, &tag, "domain"),
-					routingtable.NewEndpoint("instance-guid", false, "1.1.1.1", "2.2.2.2", 66, 99, &tag, "domain"),
+					routingtable.NewEndpoint("instance-guid", false, "1.1.1.1", "2.2.2.2", 11, 44, &tag),
+					routingtable.NewEndpoint("instance-guid", false, "1.1.1.1", "2.2.2.2", 66, 99, &tag),
 				}))
 			})
 		})
@@ -62,8 +62,8 @@ var _ = Describe("LRP Utils", func() {
 				endpoints := routingtable.NewEndpointsFromActual(actualInfo)
 
 				Expect(endpoints).To(ConsistOf([]routingtable.Endpoint{
-					routingtable.NewEndpoint("instance-guid", true, "1.1.1.1", "2.2.2.2", 11, 44, &tag, "domain"),
-					routingtable.NewEndpoint("instance-guid", true, "1.1.1.1", "2.2.2.2", 66, 99, &tag, "domain"),
+					routingtable.NewEndpoint("instance-guid", true, "1.1.1.1", "2.2.2.2", 11, 44, &tag),
+					routingtable.NewEndpoint("instance-guid", true, "1.1.1.1", "2.2.2.2", 66, 99, &tag),
 				}))
 			})
 		})

--- a/routingtable/nats_routing_table_test.go
+++ b/routingtable/nats_routing_table_test.go
@@ -37,7 +37,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "1.1.1.1",
 		ContainerIP:     "1.2.3.4",
 		Index:           0,
-		Domain:          domain,
 		Port:            11,
 		ContainerPort:   8080,
 		Evacuating:      false,
@@ -48,7 +47,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "2.2.2.2",
 		ContainerIP:     "2.3.4.5",
 		Index:           1,
-		Domain:          domain,
 		Port:            22,
 		ContainerPort:   8080,
 		Evacuating:      false,
@@ -59,7 +57,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "3.3.3.3",
 		ContainerIP:     "3.4.5.6",
 		Index:           2,
-		Domain:          domain,
 		Port:            33,
 		ContainerPort:   8080,
 		Evacuating:      false,
@@ -70,7 +67,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "1.1.1.1",
 		ContainerIP:     "1.2.3.4",
 		Index:           3,
-		Domain:          domain,
 		Port:            11,
 		ContainerPort:   8080,
 		Evacuating:      false,
@@ -81,7 +77,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "5.5.5.5",
 		ContainerIP:     "4.5.6.7",
 		Index:           0,
-		Domain:          domain,
 		Port:            55,
 		ContainerPort:   8080,
 		Evacuating:      false,
@@ -92,7 +87,6 @@ var _ = Describe("RoutingTable", func() {
 		Host:            "1.1.1.1",
 		ContainerIP:     "1.2.3.4",
 		Index:           0,
-		Domain:          domain,
 		Port:            11,
 		ContainerPort:   8080,
 		Evacuating:      true,
@@ -168,7 +162,7 @@ var _ = Describe("RoutingTable", func() {
 	) *routingtable.ActualLRPRoutingInfo {
 		return &routingtable.ActualLRPRoutingInfo{
 			ActualLRP: &models.ActualLRP{
-				ActualLRPKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, instance.Domain),
+				ActualLRPKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, domain),
 				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(instance.InstanceGUID, "cell-id"),
 				ActualLRPNetInfo: models.NewActualLRPNetInfo(
 					instance.Host,

--- a/routingtable/tcp_routing_table_test.go
+++ b/routingtable/tcp_routing_table_test.go
@@ -53,6 +53,7 @@ var _ = Describe("TCPRoutingTable", func() {
 		desiredLRP.Instances = 3
 		desiredLRP.ModificationTag = modificationTag
 		desiredLRP.Routes = tcpRoutes.RoutingInfo()
+		desiredLRP.Domain = "domain"
 
 		// add 'diego-ssh' data for testing sanitize
 		routingInfo := json.RawMessage([]byte(`{ "private_key": "fake-key" }`))


### PR DESCRIPTION
… lrps

previously the routingtable had to loop through the endpoints (i.e. actual lrp
information) to figure out the domain of the given proceess guid. Changes in
this commit:

1. store the domain as part of the RoutableEndpoints
2. copy the domain properly
3. use it in the mergeUnfreshRoutes
4. remove domain information from the endpoint