### PR TITLE
fix logger session traceability in routingtable

### DIFF
--- a/cmd/route-emitter/main.go
+++ b/cmd/route-emitter/main.go
@@ -90,7 +90,7 @@ func main() {
 	bbsClient := initializeBBSClient(logger, cfg)
 
 	localMode := cfg.CellID != ""
-	table := routingtable.NewRoutingTable(logger, cfg.RegisterDirectInstanceRoutes, metronClient)
+	table := routingtable.NewRoutingTable(cfg.RegisterDirectInstanceRoutes, metronClient)
 	natsEmitter := initializeNatsEmitter(logger, natsClient, cfg.RouteEmittingWorkers, metronClient, cfg.EnableInternalEmitter)
 
 	routeTTL := time.Duration(cfg.TCPRouteTTL)

--- a/routehandlers/handler.go
+++ b/routehandlers/handler.go
@@ -120,14 +120,14 @@ func (handler *Handler) Sync(
 	defer logger.Debug("completed")
 
 	nullLogger := lager.NewLogger("") // ignore log messsages from the routing table
-	newTable := routingtable.NewRoutingTable(nullLogger, false, handler.metronClient)
+	newTable := routingtable.NewRoutingTable(false, handler.metronClient)
 
 	for _, lrp := range desired {
-		newTable.SetRoutes(nil, lrp)
+		newTable.SetRoutes(nullLogger, nil, lrp)
 	}
 
 	for _, lrp := range actuals {
-		newTable.AddEndpoint(lrp)
+		newTable.AddEndpoint(nullLogger, lrp)
 	}
 
 	natsEmitter := handler.natsEmitter
@@ -146,7 +146,7 @@ func (handler *Handler) Sync(
 	handler.natsEmitter = natsEmitter
 	handler.routingAPIEmitter = routingAPIEmitter
 
-	routeMappings, messages := handler.routingTable.Swap(newTable, domains)
+	routeMappings, messages := handler.routingTable.Swap(nullLogger, newTable, domains)
 	logger.Debug("start-emitting-messages", lager.Data{
 		"num-registration-messages":            len(messages.RegistrationMessages),
 		"num-unregistration-messages":          len(messages.UnregistrationMessages),
@@ -175,7 +175,7 @@ func (handler *Handler) Sync(
 
 func (handler *Handler) RefreshDesired(logger lager.Logger, desiredInfo []*models.DesiredLRPSchedulingInfo) {
 	for _, desiredLRP := range desiredInfo {
-		routeMappings, messagesToEmit := handler.routingTable.SetRoutes(nil, desiredLRP)
+		routeMappings, messagesToEmit := handler.routingTable.SetRoutes(logger, nil, desiredLRP)
 		handler.emitMessages(logger, messagesToEmit, routeMappings)
 	}
 }
@@ -185,17 +185,17 @@ func (handler *Handler) ShouldRefreshDesired(actual *routingtable.ActualLRPRouti
 }
 
 func (handler *Handler) handleDesiredCreate(logger lager.Logger, desiredLRP *models.DesiredLRPSchedulingInfo) {
-	routeMappings, messagesToEmit := handler.routingTable.SetRoutes(nil, desiredLRP)
+	routeMappings, messagesToEmit := handler.routingTable.SetRoutes(logger, nil, desiredLRP)
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
 
 func (handler *Handler) handleDesiredUpdate(logger lager.Logger, before, after *models.DesiredLRPSchedulingInfo) {
-	routeMappings, messagesToEmit := handler.routingTable.SetRoutes(before, after)
+	routeMappings, messagesToEmit := handler.routingTable.SetRoutes(logger, before, after)
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
 
 func (handler *Handler) handleDesiredDelete(logger lager.Logger, schedulingInfo *models.DesiredLRPSchedulingInfo) {
-	routeMappings, messagesToEmit := handler.routingTable.RemoveRoutes(schedulingInfo)
+	routeMappings, messagesToEmit := handler.routingTable.RemoveRoutes(logger, schedulingInfo)
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
 
@@ -203,7 +203,7 @@ func (handler *Handler) handleActualCreate(logger lager.Logger, actualLRPInfo *r
 	if actualLRPInfo.ActualLRP.State != models.ActualLRPStateRunning {
 		return
 	}
-	routeMappings, messagesToEmit := handler.routingTable.AddEndpoint(actualLRPInfo)
+	routeMappings, messagesToEmit := handler.routingTable.AddEndpoint(logger, actualLRPInfo)
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
 
@@ -214,9 +214,9 @@ func (handler *Handler) handleActualUpdate(logger lager.Logger, before, after *r
 	)
 	switch {
 	case after.ActualLRP.State == models.ActualLRPStateRunning:
-		routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(after)
+		routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(logger, after)
 	case after.ActualLRP.State != models.ActualLRPStateRunning && before.ActualLRP.State == models.ActualLRPStateRunning:
-		routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(before)
+		routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(logger, before)
 	}
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
@@ -225,7 +225,7 @@ func (handler *Handler) handleActualDelete(logger lager.Logger, actualLRPInfo *r
 	if actualLRPInfo.ActualLRP.State != models.ActualLRPStateRunning {
 		return
 	}
-	routeMappings, messagesToEmit := handler.routingTable.RemoveEndpoint(actualLRPInfo)
+	routeMappings, messagesToEmit := handler.routingTable.RemoveEndpoint(logger, actualLRPInfo)
 	handler.emitMessages(logger, messagesToEmit, routeMappings)
 }
 

--- a/routehandlers/handler_test.go
+++ b/routehandlers/handler_test.go
@@ -6,6 +6,7 @@ import (
 
 	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	loggregator "code.cloudfoundry.org/go-loggregator"
+	"code.cloudfoundry.org/lager"
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/lager/lagertest"
@@ -148,7 +149,7 @@ var _ = Describe("Handler", func() {
 
 			It("should set the routes on the table", func() {
 				Expect(fakeTable.SetRoutesCallCount()).To(Equal(1))
-				before, after := fakeTable.SetRoutesArgsForCall(0)
+				_, before, after := fakeTable.SetRoutesArgsForCall(0)
 				Expect(before).To(BeNil())
 				Expect(*after).To(Equal(desiredLRP.DesiredLRPSchedulingInfo()))
 			})
@@ -241,7 +242,7 @@ var _ = Describe("Handler", func() {
 
 			It("should set the routes on the table", func() {
 				Expect(fakeTable.SetRoutesCallCount()).To(Equal(1))
-				before, after := fakeTable.SetRoutesArgsForCall(0)
+				_, before, after := fakeTable.SetRoutesArgsForCall(0)
 				Expect(*before).To(Equal(originalDesiredLRP.DesiredLRPSchedulingInfo()))
 				Expect(*after).To(Equal(changedDesiredLRP.DesiredLRPSchedulingInfo()))
 			})
@@ -309,7 +310,7 @@ var _ = Describe("Handler", func() {
 
 			It("should remove the routes from the table", func() {
 				Expect(fakeTable.RemoveRoutesCallCount()).To(Equal(1))
-				lrp := fakeTable.RemoveRoutesArgsForCall(0)
+				_, lrp := fakeTable.RemoveRoutesArgsForCall(0)
 				Expect(*lrp).To(Equal(desiredLRP.DesiredLRPSchedulingInfo()))
 			})
 
@@ -377,7 +378,7 @@ var _ = Describe("Handler", func() {
 
 				It("should add/update the endpoints on the table", func() {
 					Expect(fakeTable.AddEndpointCallCount()).To(Equal(1))
-					lrpInfo := fakeTable.AddEndpointArgsForCall(0)
+					_, lrpInfo := fakeTable.AddEndpointArgsForCall(0)
 					Expect(lrpInfo).To(Equal(actualLRPRoutingInfo))
 				})
 
@@ -494,7 +495,7 @@ var _ = Describe("Handler", func() {
 						Evacuating: evacuating,
 					}
 
-					actualLRP := fakeTable.AddEndpointArgsForCall(0)
+					_, actualLRP := fakeTable.AddEndpointArgsForCall(0)
 					Expect(actualLRP).To(Equal(routingInfo))
 				})
 
@@ -561,7 +562,7 @@ var _ = Describe("Handler", func() {
 						Evacuating: evacuating,
 					}
 
-					routingInfo := fakeTable.RemoveEndpointArgsForCall(0)
+					_, routingInfo := fakeTable.RemoveEndpointArgsForCall(0)
 					Expect(routingInfo).To(Equal(lrpRoutingInfo))
 				})
 
@@ -658,7 +659,7 @@ var _ = Describe("Handler", func() {
 						ActualLRP:  lrp,
 						Evacuating: evacuating,
 					}
-					routingInfo := fakeTable.RemoveEndpointArgsForCall(0)
+					_, routingInfo := fakeTable.RemoveEndpointArgsForCall(0)
 					Expect(routingInfo).To(Equal(lrpRoutingInfo))
 				})
 
@@ -853,7 +854,7 @@ var _ = Describe("Handler", func() {
 					return byRoutingKey
 				}
 
-				fakeTable.SwapStub = func(t routingtable.RoutingTable, d models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+				fakeTable.SwapStub = func(l lager.Logger, t routingtable.RoutingTable, d models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 
 					routes := routesByRoutingKey(desiredInfo)
 					routesList := make([]routingtable.Route, 3)
@@ -874,7 +875,7 @@ var _ = Describe("Handler", func() {
 			It("updates the routing table", func() {
 				routeHandler.Sync(logger, desiredInfo, actualInfo, domains, nil)
 				Expect(fakeTable.SwapCallCount()).Should(Equal(1))
-				tempRoutingTable, swapDomains := fakeTable.SwapArgsForCall(0)
+				_, tempRoutingTable, swapDomains := fakeTable.SwapArgsForCall(0)
 				Expect(tempRoutingTable.HTTPAssociationsCount()).To(Equal(3))
 				Expect(swapDomains).To(Equal(domains))
 
@@ -944,7 +945,7 @@ var _ = Describe("Handler", func() {
 
 				It("updates the routing table and emit cached events", func() {
 					Expect(fakeTable.SwapCallCount()).Should(Equal(1))
-					tempRoutingTable, _ := fakeTable.SwapArgsForCall(0)
+					_, tempRoutingTable, _ := fakeTable.SwapArgsForCall(0)
 					Expect(tempRoutingTable.HTTPAssociationsCount()).Should(Equal(4))
 					Expect(natsEmitter.EmitCallCount()).Should(Equal(1))
 				})
@@ -1095,7 +1096,7 @@ var _ = Describe("Handler", func() {
 			routeHandler.RefreshDesired(logger, []*models.DesiredLRPSchedulingInfo{desiredInfo})
 
 			Expect(fakeTable.SetRoutesCallCount()).To(Equal(1))
-			before, after := fakeTable.SetRoutesArgsForCall(0)
+			_, before, after := fakeTable.SetRoutesArgsForCall(0)
 			Expect(before).To(BeNil())
 			Expect(after).To(Equal(desiredInfo))
 			Expect(natsEmitter.EmitCallCount()).Should(Equal(1))

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -68,7 +68,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 			It("invokes AddRoutes on RoutingTable", func() {
 				Expect(fakeRoutingTable.SetRoutesCallCount()).Should(Equal(1))
-				before, after := fakeRoutingTable.SetRoutesArgsForCall(0)
+				_, before, after := fakeRoutingTable.SetRoutesArgsForCall(0)
 				Expect(before).To(BeNil())
 				Expect(*after).Should(Equal(desiredLRP.DesiredLRPSchedulingInfo()))
 			})
@@ -112,7 +112,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 			It("invokes UpdateRoutes on RoutingTable", func() {
 				Expect(fakeRoutingTable.SetRoutesCallCount()).Should(Equal(1))
-				beforeLrp, afterLrp := fakeRoutingTable.SetRoutesArgsForCall(0)
+				_, beforeLrp, afterLrp := fakeRoutingTable.SetRoutesArgsForCall(0)
 				Expect(*beforeLrp).Should(Equal(desiredLRP.DesiredLRPSchedulingInfo()))
 				Expect(*afterLrp).Should(Equal(after.DesiredLRPSchedulingInfo()))
 			})
@@ -144,7 +144,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 			It("does not invoke AddRoutes on RoutingTable", func() {
 				Expect(fakeRoutingTable.RemoveRoutesCallCount()).Should(Equal(1))
 				Expect(fakeRoutingAPIEmitter.EmitCallCount()).Should(Equal(1))
-				lrp := fakeRoutingTable.RemoveRoutesArgsForCall(0)
+				_, lrp := fakeRoutingTable.RemoveRoutesArgsForCall(0)
 				Expect(*lrp).Should(Equal(desiredLRP.DesiredLRPSchedulingInfo()))
 			})
 		})
@@ -186,7 +186,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				It("invokes AddEndpoint on RoutingTable", func() {
 					Expect(fakeRoutingTable.AddEndpointCallCount()).Should(Equal(1))
-					lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
+					_, lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
 					Expect(lrp).Should(Equal(routingtable.NewActualLRPRoutingInfo(actualLRP)))
 				})
 
@@ -271,7 +271,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				It("invokes AddEndpoint on RoutingTable", func() {
 					Expect(fakeRoutingTable.AddEndpointCallCount()).Should(Equal(1))
-					lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
+					_, lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
 					Expect(lrp.ActualLRP).Should(Equal(afterLRP.Instance))
 				})
 
@@ -320,7 +320,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				It("invokes RemoveEndpoint on RoutingTable", func() {
 					Expect(fakeRoutingTable.RemoveEndpointCallCount()).Should(Equal(1))
-					lrp := fakeRoutingTable.RemoveEndpointArgsForCall(0)
+					_, lrp := fakeRoutingTable.RemoveEndpointArgsForCall(0)
 					Expect(lrp).Should(Equal(routingtable.NewActualLRPRoutingInfo(actualLRP)))
 				})
 
@@ -400,7 +400,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				It("invokes RemoveEndpoint on RoutingTable", func() {
 					Expect(fakeRoutingTable.RemoveEndpointCallCount()).Should(Equal(1))
-					lrp := fakeRoutingTable.RemoveEndpointArgsForCall(0)
+					_, lrp := fakeRoutingTable.RemoveEndpointArgsForCall(0)
 					Expect(lrp).Should(Equal(routingtable.NewActualLRPRoutingInfo(actualLRP)))
 				})
 
@@ -512,7 +512,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 			routeHandler.RefreshDesired(logger, []*models.DesiredLRPSchedulingInfo{desiredInfo})
 
 			Expect(fakeRoutingTable.SetRoutesCallCount()).To(Equal(1))
-			_, after := fakeRoutingTable.SetRoutesArgsForCall(0)
+			_, _, after := fakeRoutingTable.SetRoutesArgsForCall(0)
 			Expect(after).To(Equal(desiredInfo))
 			Expect(fakeRoutingAPIEmitter.EmitCallCount()).Should(Equal(1))
 		})
@@ -566,7 +566,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 					},
 				}
 
-				fakeRoutingTable.SwapStub = func(t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+				fakeRoutingTable.SwapStub = func(l lager.Logger, t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 					return routingtable.TCPRouteMappings{}, emptyNatsMessages
 				}
 			})
@@ -608,7 +608,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 				domains.Add("foo")
 				routeHandler.Sync(logger, desiredInfo, actualInfo, domains, nil)
 				Expect(fakeRoutingTable.SwapCallCount()).Should(Equal(1))
-				tempRoutingTable, actualDomains := fakeRoutingTable.SwapArgsForCall(0)
+				_, tempRoutingTable, actualDomains := fakeRoutingTable.SwapArgsForCall(0)
 				Expect(actualDomains).To(Equal(domains))
 				Expect(tempRoutingTable.TCPAssociationsCount()).To(Equal(1))
 				routingEvents, _ := tempRoutingTable.GetExternalRoutingEvents()
@@ -670,7 +670,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				It("updates the routing table and emit cached events", func() {
 					Expect(fakeRoutingTable.SwapCallCount()).Should(Equal(1))
-					tempRoutingTable, _ := fakeRoutingTable.SwapArgsForCall(0)
+					_, tempRoutingTable, _ := fakeRoutingTable.SwapArgsForCall(0)
 					Expect(tempRoutingTable.TCPAssociationsCount()).Should(Equal(2))
 					Expect(fakeRoutingAPIEmitter.EmitCallCount()).To(Equal(1))
 				})

--- a/routingtable/fakeroutingtable/fake_routingtable.go
+++ b/routingtable/fakeroutingtable/fake_routingtable.go
@@ -5,13 +5,15 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/bbs/models"
+	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/route-emitter/routingtable"
 )
 
 type FakeRoutingTable struct {
-	SetRoutesStub        func(beforeLRP, afterLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
+	SetRoutesStub        func(logger lager.Logger, beforeLRP, afterLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
 	setRoutesMutex       sync.RWMutex
 	setRoutesArgsForCall []struct {
+		logger    lager.Logger
 		beforeLRP *models.DesiredLRPSchedulingInfo
 		afterLRP  *models.DesiredLRPSchedulingInfo
 	}
@@ -23,9 +25,10 @@ type FakeRoutingTable struct {
 		result1 routingtable.TCPRouteMappings
 		result2 routingtable.MessagesToEmit
 	}
-	RemoveRoutesStub        func(desiredLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
+	RemoveRoutesStub        func(logger lager.Logger, desiredLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
 	removeRoutesMutex       sync.RWMutex
 	removeRoutesArgsForCall []struct {
+		logger     lager.Logger
 		desiredLRP *models.DesiredLRPSchedulingInfo
 	}
 	removeRoutesReturns struct {
@@ -36,9 +39,10 @@ type FakeRoutingTable struct {
 		result1 routingtable.TCPRouteMappings
 		result2 routingtable.MessagesToEmit
 	}
-	AddEndpointStub        func(actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
+	AddEndpointStub        func(logger lager.Logger, actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
 	addEndpointMutex       sync.RWMutex
 	addEndpointArgsForCall []struct {
+		logger    lager.Logger
 		actualLRP *routingtable.ActualLRPRoutingInfo
 	}
 	addEndpointReturns struct {
@@ -49,9 +53,10 @@ type FakeRoutingTable struct {
 		result1 routingtable.TCPRouteMappings
 		result2 routingtable.MessagesToEmit
 	}
-	RemoveEndpointStub        func(actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
+	RemoveEndpointStub        func(logger lager.Logger, actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
 	removeEndpointMutex       sync.RWMutex
 	removeEndpointArgsForCall []struct {
+		logger    lager.Logger
 		actualLRP *routingtable.ActualLRPRoutingInfo
 	}
 	removeEndpointReturns struct {
@@ -62,9 +67,10 @@ type FakeRoutingTable struct {
 		result1 routingtable.TCPRouteMappings
 		result2 routingtable.MessagesToEmit
 	}
-	SwapStub        func(t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
+	SwapStub        func(logger lager.Logger, t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit)
 	swapMutex       sync.RWMutex
 	swapArgsForCall []struct {
+		logger  lager.Logger
 		t       routingtable.RoutingTable
 		domains models.DomainSet
 	}
@@ -149,17 +155,18 @@ type FakeRoutingTable struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRoutingTable) SetRoutes(beforeLRP *models.DesiredLRPSchedulingInfo, afterLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+func (fake *FakeRoutingTable) SetRoutes(logger lager.Logger, beforeLRP *models.DesiredLRPSchedulingInfo, afterLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 	fake.setRoutesMutex.Lock()
 	ret, specificReturn := fake.setRoutesReturnsOnCall[len(fake.setRoutesArgsForCall)]
 	fake.setRoutesArgsForCall = append(fake.setRoutesArgsForCall, struct {
+		logger    lager.Logger
 		beforeLRP *models.DesiredLRPSchedulingInfo
 		afterLRP  *models.DesiredLRPSchedulingInfo
-	}{beforeLRP, afterLRP})
-	fake.recordInvocation("SetRoutes", []interface{}{beforeLRP, afterLRP})
+	}{logger, beforeLRP, afterLRP})
+	fake.recordInvocation("SetRoutes", []interface{}{logger, beforeLRP, afterLRP})
 	fake.setRoutesMutex.Unlock()
 	if fake.SetRoutesStub != nil {
-		return fake.SetRoutesStub(beforeLRP, afterLRP)
+		return fake.SetRoutesStub(logger, beforeLRP, afterLRP)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -173,10 +180,10 @@ func (fake *FakeRoutingTable) SetRoutesCallCount() int {
 	return len(fake.setRoutesArgsForCall)
 }
 
-func (fake *FakeRoutingTable) SetRoutesArgsForCall(i int) (*models.DesiredLRPSchedulingInfo, *models.DesiredLRPSchedulingInfo) {
+func (fake *FakeRoutingTable) SetRoutesArgsForCall(i int) (lager.Logger, *models.DesiredLRPSchedulingInfo, *models.DesiredLRPSchedulingInfo) {
 	fake.setRoutesMutex.RLock()
 	defer fake.setRoutesMutex.RUnlock()
-	return fake.setRoutesArgsForCall[i].beforeLRP, fake.setRoutesArgsForCall[i].afterLRP
+	return fake.setRoutesArgsForCall[i].logger, fake.setRoutesArgsForCall[i].beforeLRP, fake.setRoutesArgsForCall[i].afterLRP
 }
 
 func (fake *FakeRoutingTable) SetRoutesReturns(result1 routingtable.TCPRouteMappings, result2 routingtable.MessagesToEmit) {
@@ -201,16 +208,17 @@ func (fake *FakeRoutingTable) SetRoutesReturnsOnCall(i int, result1 routingtable
 	}{result1, result2}
 }
 
-func (fake *FakeRoutingTable) RemoveRoutes(desiredLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+func (fake *FakeRoutingTable) RemoveRoutes(logger lager.Logger, desiredLRP *models.DesiredLRPSchedulingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 	fake.removeRoutesMutex.Lock()
 	ret, specificReturn := fake.removeRoutesReturnsOnCall[len(fake.removeRoutesArgsForCall)]
 	fake.removeRoutesArgsForCall = append(fake.removeRoutesArgsForCall, struct {
+		logger     lager.Logger
 		desiredLRP *models.DesiredLRPSchedulingInfo
-	}{desiredLRP})
-	fake.recordInvocation("RemoveRoutes", []interface{}{desiredLRP})
+	}{logger, desiredLRP})
+	fake.recordInvocation("RemoveRoutes", []interface{}{logger, desiredLRP})
 	fake.removeRoutesMutex.Unlock()
 	if fake.RemoveRoutesStub != nil {
-		return fake.RemoveRoutesStub(desiredLRP)
+		return fake.RemoveRoutesStub(logger, desiredLRP)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -224,10 +232,10 @@ func (fake *FakeRoutingTable) RemoveRoutesCallCount() int {
 	return len(fake.removeRoutesArgsForCall)
 }
 
-func (fake *FakeRoutingTable) RemoveRoutesArgsForCall(i int) *models.DesiredLRPSchedulingInfo {
+func (fake *FakeRoutingTable) RemoveRoutesArgsForCall(i int) (lager.Logger, *models.DesiredLRPSchedulingInfo) {
 	fake.removeRoutesMutex.RLock()
 	defer fake.removeRoutesMutex.RUnlock()
-	return fake.removeRoutesArgsForCall[i].desiredLRP
+	return fake.removeRoutesArgsForCall[i].logger, fake.removeRoutesArgsForCall[i].desiredLRP
 }
 
 func (fake *FakeRoutingTable) RemoveRoutesReturns(result1 routingtable.TCPRouteMappings, result2 routingtable.MessagesToEmit) {
@@ -252,16 +260,17 @@ func (fake *FakeRoutingTable) RemoveRoutesReturnsOnCall(i int, result1 routingta
 	}{result1, result2}
 }
 
-func (fake *FakeRoutingTable) AddEndpoint(actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+func (fake *FakeRoutingTable) AddEndpoint(logger lager.Logger, actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 	fake.addEndpointMutex.Lock()
 	ret, specificReturn := fake.addEndpointReturnsOnCall[len(fake.addEndpointArgsForCall)]
 	fake.addEndpointArgsForCall = append(fake.addEndpointArgsForCall, struct {
+		logger    lager.Logger
 		actualLRP *routingtable.ActualLRPRoutingInfo
-	}{actualLRP})
-	fake.recordInvocation("AddEndpoint", []interface{}{actualLRP})
+	}{logger, actualLRP})
+	fake.recordInvocation("AddEndpoint", []interface{}{logger, actualLRP})
 	fake.addEndpointMutex.Unlock()
 	if fake.AddEndpointStub != nil {
-		return fake.AddEndpointStub(actualLRP)
+		return fake.AddEndpointStub(logger, actualLRP)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -275,10 +284,10 @@ func (fake *FakeRoutingTable) AddEndpointCallCount() int {
 	return len(fake.addEndpointArgsForCall)
 }
 
-func (fake *FakeRoutingTable) AddEndpointArgsForCall(i int) *routingtable.ActualLRPRoutingInfo {
+func (fake *FakeRoutingTable) AddEndpointArgsForCall(i int) (lager.Logger, *routingtable.ActualLRPRoutingInfo) {
 	fake.addEndpointMutex.RLock()
 	defer fake.addEndpointMutex.RUnlock()
-	return fake.addEndpointArgsForCall[i].actualLRP
+	return fake.addEndpointArgsForCall[i].logger, fake.addEndpointArgsForCall[i].actualLRP
 }
 
 func (fake *FakeRoutingTable) AddEndpointReturns(result1 routingtable.TCPRouteMappings, result2 routingtable.MessagesToEmit) {
@@ -303,16 +312,17 @@ func (fake *FakeRoutingTable) AddEndpointReturnsOnCall(i int, result1 routingtab
 	}{result1, result2}
 }
 
-func (fake *FakeRoutingTable) RemoveEndpoint(actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+func (fake *FakeRoutingTable) RemoveEndpoint(logger lager.Logger, actualLRP *routingtable.ActualLRPRoutingInfo) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 	fake.removeEndpointMutex.Lock()
 	ret, specificReturn := fake.removeEndpointReturnsOnCall[len(fake.removeEndpointArgsForCall)]
 	fake.removeEndpointArgsForCall = append(fake.removeEndpointArgsForCall, struct {
+		logger    lager.Logger
 		actualLRP *routingtable.ActualLRPRoutingInfo
-	}{actualLRP})
-	fake.recordInvocation("RemoveEndpoint", []interface{}{actualLRP})
+	}{logger, actualLRP})
+	fake.recordInvocation("RemoveEndpoint", []interface{}{logger, actualLRP})
 	fake.removeEndpointMutex.Unlock()
 	if fake.RemoveEndpointStub != nil {
-		return fake.RemoveEndpointStub(actualLRP)
+		return fake.RemoveEndpointStub(logger, actualLRP)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -326,10 +336,10 @@ func (fake *FakeRoutingTable) RemoveEndpointCallCount() int {
 	return len(fake.removeEndpointArgsForCall)
 }
 
-func (fake *FakeRoutingTable) RemoveEndpointArgsForCall(i int) *routingtable.ActualLRPRoutingInfo {
+func (fake *FakeRoutingTable) RemoveEndpointArgsForCall(i int) (lager.Logger, *routingtable.ActualLRPRoutingInfo) {
 	fake.removeEndpointMutex.RLock()
 	defer fake.removeEndpointMutex.RUnlock()
-	return fake.removeEndpointArgsForCall[i].actualLRP
+	return fake.removeEndpointArgsForCall[i].logger, fake.removeEndpointArgsForCall[i].actualLRP
 }
 
 func (fake *FakeRoutingTable) RemoveEndpointReturns(result1 routingtable.TCPRouteMappings, result2 routingtable.MessagesToEmit) {
@@ -354,17 +364,18 @@ func (fake *FakeRoutingTable) RemoveEndpointReturnsOnCall(i int, result1 routing
 	}{result1, result2}
 }
 
-func (fake *FakeRoutingTable) Swap(t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
+func (fake *FakeRoutingTable) Swap(logger lager.Logger, t routingtable.RoutingTable, domains models.DomainSet) (routingtable.TCPRouteMappings, routingtable.MessagesToEmit) {
 	fake.swapMutex.Lock()
 	ret, specificReturn := fake.swapReturnsOnCall[len(fake.swapArgsForCall)]
 	fake.swapArgsForCall = append(fake.swapArgsForCall, struct {
+		logger  lager.Logger
 		t       routingtable.RoutingTable
 		domains models.DomainSet
-	}{t, domains})
-	fake.recordInvocation("Swap", []interface{}{t, domains})
+	}{logger, t, domains})
+	fake.recordInvocation("Swap", []interface{}{logger, t, domains})
 	fake.swapMutex.Unlock()
 	if fake.SwapStub != nil {
-		return fake.SwapStub(t, domains)
+		return fake.SwapStub(logger, t, domains)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -378,10 +389,10 @@ func (fake *FakeRoutingTable) SwapCallCount() int {
 	return len(fake.swapArgsForCall)
 }
 
-func (fake *FakeRoutingTable) SwapArgsForCall(i int) (routingtable.RoutingTable, models.DomainSet) {
+func (fake *FakeRoutingTable) SwapArgsForCall(i int) (lager.Logger, routingtable.RoutingTable, models.DomainSet) {
 	fake.swapMutex.RLock()
 	defer fake.swapMutex.RUnlock()
-	return fake.swapArgsForCall[i].t, fake.swapArgsForCall[i].domains
+	return fake.swapArgsForCall[i].logger, fake.swapArgsForCall[i].t, fake.swapArgsForCall[i].domains
 }
 
 func (fake *FakeRoutingTable) SwapReturns(result1 routingtable.TCPRouteMappings, result2 routingtable.MessagesToEmit) {

--- a/watcher/watcher_integration_test.go
+++ b/watcher/watcher_integration_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Watcher Integration", func() {
 		Expect(err).NotTo(HaveOccurred())
 		fakeMetronClient = &mfakes.FakeIngressClient{}
 		natsEmitter := emitter.NewNATSEmitter(natsClient, workPool, logger, fakeMetronClient, false)
-		natsTable := routingtable.NewRoutingTable(logger, false, fakeMetronClient)
+		natsTable := routingtable.NewRoutingTable(false, fakeMetronClient)
 
 		uaaClient := uaaclient.NewNoOpUaaClient()
 		routingAPIEmitter := emitter.NewRoutingAPIEmitter(logger, routingApiClient, uaaClient, 100)


### PR DESCRIPTION
Creating a separate Logger in the RoutingTable loses some of the tracking we do by passing a logger session through. This PR passes the logger from the event handler through to the routing table functions.

Signed-off-by: Nima Kaviani <nkavian@us.ibm.com>