### PR TITLE
Enable `cf ssh` for Windows+Linux with 3rd Party Network Plugins

### DIFF
--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Route Emitter", func() {
 		lrpKey = models.NewActualLRPKey(processGuid, index, domain)
 		instanceKey = models.NewActualLRPInstanceKey("iguid1", "cell-id")
 
-		netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", models.NewPortMapping(65100, 8080))
+		netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", false, models.NewPortMapping(65100, 8080))
 		registeredRoutes = listenForRoutes("router.register")
 		unregisteredRoutes = listenForRoutes("router.unregister")
 
@@ -503,7 +503,7 @@ var _ = Describe("Route Emitter", func() {
 							Expect(bbsClient.DesireLRP(logger, &desiredLRP)).NotTo(HaveOccurred())
 							lrpKey := models.NewActualLRPKey("some-guid", 0, domain)
 							instanceKey := models.NewActualLRPInstanceKey("instance-guid", "cell-id")
-							netInfo := models.NewActualLRPNetInfo("some-ip", "container-ip", models.NewPortMapping(62003, 5222))
+							netInfo := models.NewActualLRPNetInfo("some-ip", "container-ip", false, models.NewPortMapping(62003, 5222))
 							Expect(bbsClient.StartActualLRP(logger, &lrpKey, &instanceKey, &netInfo))
 
 						})
@@ -629,7 +629,7 @@ var _ = Describe("Route Emitter", func() {
 							Eventually(runner).Should(gbytes.Say("succeeded-getting-actual-lrps"))
 							lrpKey = models.NewActualLRPKey(processGUID, 0, domain)
 							instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
-							netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.NewPortMapping(5222, 5222))
+							netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", false, models.NewPortMapping(5222, 5222))
 							Expect(bbsClient.StartActualLRP(logger, &lrpKey, &instanceKey, &netInfo)).To(Succeed())
 							Eventually(runner).Should(gbytes.Say("caching-event"))
 
@@ -684,7 +684,7 @@ var _ = Describe("Route Emitter", func() {
 					BeforeEach(func() {
 						lrpKey = models.NewActualLRPKey(expectedTCPProcessGUID, 0, domain)
 						instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
-						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.NewPortMapping(62003, 5222))
+						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", false, models.NewPortMapping(62003, 5222))
 						Expect(bbsClient.StartActualLRP(logger, &lrpKey, &instanceKey, &netInfo))
 					})
 
@@ -861,7 +861,7 @@ var _ = Describe("Route Emitter", func() {
 						By("waiting for the sync loop to start")
 						lrpKey = models.NewActualLRPKey(expectedTCPProcessGUID, 0, domain)
 						instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
-						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.NewPortMapping(5222, 5222))
+						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", false, models.NewPortMapping(5222, 5222))
 						Expect(bbsClient.StartActualLRP(logger, &lrpKey, &instanceKey, &netInfo)).To(Succeed())
 						Eventually(runner).Should(gbytes.Say("caching-event"))
 
@@ -897,7 +897,7 @@ var _ = Describe("Route Emitter", func() {
 
 					key := models.NewActualLRPKey("some-guid-1", 0, domain)
 					instanceKey := models.NewActualLRPInstanceKey("instance-guid-1", "cell-id")
-					netInfo := models.NewActualLRPNetInfo("some-ip-1", "container-ip-1", models.NewPortMapping(62003, 1883))
+					netInfo := models.NewActualLRPNetInfo("some-ip-1", "container-ip-1", false, models.NewPortMapping(62003, 1883))
 					Expect(bbsClient.StartActualLRP(logger, &key, &instanceKey, &netInfo))
 				})
 
@@ -1284,7 +1284,7 @@ var _ = Describe("Route Emitter", func() {
 
 				Context("and the TLS proxy port is set on the Actual LRP", func() {
 					BeforeEach(func() {
-						netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", models.NewPortMappingWithTLSProxy(65100, 8080, 61006, 61007))
+						netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", false, models.NewPortMappingWithTLSProxy(65100, 8080, 61006, 61007))
 					})
 
 					It("emits a route with the TLS proxy port set", func() {
@@ -1361,7 +1361,7 @@ var _ = Describe("Route Emitter", func() {
 
 					Context("and the TLS proxy port is set on the Actual LRP", func() {
 						BeforeEach(func() {
-							netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", models.NewPortMappingWithTLSProxy(65100, 8080, 61006, 61007))
+							netInfo = models.NewActualLRPNetInfo("1.2.3.4", "2.2.2.2", false, models.NewPortMappingWithTLSProxy(65100, 8080, 61006, 61007))
 						})
 
 						It("emits a route with the container TLS proxy port set", func() {

--- a/routehandlers/handler_test.go
+++ b/routehandlers/handler_test.go
@@ -371,6 +371,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedExternalPort, expectedAdditionalContainerPort),
 						),
@@ -420,6 +421,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedExternalPort, expectedAdditionalContainerPort),
 						),
@@ -470,6 +472,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
@@ -544,6 +547,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
@@ -727,6 +731,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
@@ -775,6 +780,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
@@ -808,6 +814,7 @@ var _ = Describe("Handler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							expectedHost,
 							expectedInstanceAddress,
+							false,
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
@@ -933,21 +940,21 @@ var _ = Describe("Handler", func() {
 				actualLRP1 := &models.ActualLRP{
 					ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
 					ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip-1", models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip-1", false, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 					State:                models.ActualLRPStateRunning,
 				}
 
 				actualLRP2 := &models.ActualLRP{
 					ActualLRPKey:         models.NewActualLRPKey("pg-2", 0, "domain"),
 					ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint2.InstanceGUID, "cell-id"),
-					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint2.Host, "container-ip-2", models.NewPortMapping(endpoint2.Port, endpoint2.ContainerPort)),
+					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint2.Host, "container-ip-2", false, models.NewPortMapping(endpoint2.Port, endpoint2.ContainerPort)),
 					State:                models.ActualLRPStateRunning,
 				}
 
 				actualLRP3 := &models.ActualLRP{
 					ActualLRPKey:         models.NewActualLRPKey("pg-3", 1, "domain"),
 					ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint3.InstanceGUID, "cell-id"),
-					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint3.Host, "container-ip-3", models.NewPortMapping(endpoint3.Port, endpoint3.ContainerPort)),
+					ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint3.Host, "container-ip-3", false, models.NewPortMapping(endpoint3.Port, endpoint3.ContainerPort)),
 					State:                models.ActualLRPStateRunning,
 				}
 
@@ -1057,7 +1064,7 @@ var _ = Describe("Handler", func() {
 					actualLRPEvent := models.NewActualLRPInstanceCreatedEvent(&models.ActualLRP{
 						ActualLRPKey:         models.NewActualLRPKey("pg-4", 0, "domain"),
 						ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint4.InstanceGUID, "cell-id"),
-						ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint4.Host, "container-ip-4", models.NewPortMapping(endpoint4.Port, endpoint4.ContainerPort)),
+						ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint4.Host, "container-ip-4", false, models.NewPortMapping(endpoint4.Port, endpoint4.ContainerPort)),
 						State:                models.ActualLRPStateRunning,
 					})
 
@@ -1253,8 +1260,10 @@ var _ = Describe("Handler", func() {
 			actualLRP = &models.ActualLRP{
 				ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
 				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-				ActualLRPNetInfo: models.NewActualLRPNetInfo(endpoint1.Host,
+				ActualLRPNetInfo: models.NewActualLRPNetInfo(
+					endpoint1.Host,
 					"container-ip-1",
+					false,
 					models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort),
 					models.NewPortMapping(12, endpoint1.ContainerPort+1),
 				),

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -175,6 +175,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(611006, 5222),
 						),
 						State: models.ActualLRPStateRunning,
@@ -208,6 +209,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(611006, 5222),
 						),
 						State: models.ActualLRPStateClaimed,
@@ -241,6 +243,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
+							false,
 						),
 						State: models.ActualLRPStateClaimed,
 					}
@@ -251,6 +254,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(611006, 5222),
 						),
 						State: models.ActualLRPStateRunning,
@@ -284,6 +288,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(611006, 5222),
 						),
 						State: models.ActualLRPStateRunning,
@@ -295,6 +300,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
+							false,
 						),
 						State: models.ActualLRPStateCrashed,
 					}
@@ -327,6 +333,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
+							false,
 						),
 						State: models.ActualLRPStateUnclaimed,
 					}
@@ -337,6 +344,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
+							false,
 						),
 						State: models.ActualLRPStateClaimed,
 					}
@@ -365,6 +373,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(611006, 5222),
 						),
 						State: models.ActualLRPStateRunning,
@@ -398,6 +407,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
+							false,
 						),
 						State: models.ActualLRPStateClaimed,
 					}
@@ -423,6 +433,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 				ActualLRPNetInfo: models.NewActualLRPNetInfo(
 					"some-ip",
 					"container-ip",
+					false,
 					models.NewPortMapping(61006, 5222),
 					models.NewPortMapping(61007, 5223),
 				),
@@ -523,6 +534,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
+							false,
 							models.NewPortMapping(61006, containerPort),
 						),
 						State:           models.ActualLRPStateRunning,
@@ -611,6 +623,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"some-ip-2",
 							"container-ip-2",
+							false,
 							models.NewPortMapping(61006, 5222),
 						),
 						State:           models.ActualLRPStateRunning,

--- a/routingtable/endpoint_utils_test.go
+++ b/routingtable/endpoint_utils_test.go
@@ -20,6 +20,7 @@ var _ = Describe("LRP Utils", func() {
 					ActualLRPNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
+						false,
 						models.NewPortMapping(11, 44),
 						models.NewPortMapping(66, 99),
 					),
@@ -45,6 +46,7 @@ var _ = Describe("LRP Utils", func() {
 						ActualLRPNetInfo: models.NewActualLRPNetInfo(
 							"1.1.1.1",
 							"2.2.2.2",
+							false,
 							models.NewPortMappingWithTLSProxy(11, 44, 61004, 61005),
 							models.NewPortMappingWithTLSProxy(66, 99, 61006, 61007),
 						),
@@ -73,6 +75,7 @@ var _ = Describe("LRP Utils", func() {
 					ActualLRPNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
+						false,
 						models.NewPortMapping(11, 44),
 						models.NewPortMapping(66, 99),
 					),
@@ -99,6 +102,7 @@ var _ = Describe("LRP Utils", func() {
 				ActualLRPNetInfo: models.NewActualLRPNetInfo(
 					"1.1.1.1",
 					"2.2.2.2",
+					false,
 					models.NewPortMapping(11, 44),
 					models.NewPortMapping(66, 99),
 				),
@@ -118,6 +122,7 @@ var _ = Describe("LRP Utils", func() {
 					ActualLRPNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
+						false,
 						models.NewPortMappingWithTLSProxy(11, 44, 61004, 61005),
 						models.NewPortMappingWithTLSProxy(66, 99, 61006, 61007),
 					),
@@ -140,6 +145,7 @@ var _ = Describe("LRP Utils", func() {
 					ActualLRPNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
+						false,
 					),
 					State: models.ActualLRPStateRunning,
 				})

--- a/routingtable/routingtable_test.go
+++ b/routingtable/routingtable_test.go
@@ -103,6 +103,7 @@ func createActualLRP(
 		ActualLRPNetInfo: models.NewActualLRPNetInfo(
 			instance.Host,
 			instance.ContainerIP,
+			false,
 			portMapping,
 		),
 		Presence:        instance.Presence,
@@ -125,6 +126,7 @@ func createActualLRPWithPortMappings(
 		ActualLRPNetInfo: models.NewActualLRPNetInfo(
 			instance.Host,
 			instance.ContainerIP,
+			false,
 			ports...,
 		),
 		Presence:        instance.Presence,

--- a/routingtable/tcp_routing_table_test.go
+++ b/routingtable/tcp_routing_table_test.go
@@ -76,6 +76,7 @@ var _ = Describe("TCPRoutingTable", func() {
 			ActualLRPNetInfo: models.NewActualLRPNetInfo(
 				hostAddress,
 				instanceAddress,
+				false,
 				models.NewPortMapping(hostPort, containerPort),
 			),
 			Presence:        models.ActualLRP_Ordinary,
@@ -906,6 +907,7 @@ var _ = Describe("TCPRoutingTable", func() {
 								newActualLRP.ActualLRPNetInfo = models.NewActualLRPNetInfo(
 									"some-ip-1",
 									"container-ip-1",
+									false,
 									models.NewPortMapping(62004, 5222),
 									models.NewPortMapping(62005, 5223),
 								)

--- a/watcher/watcher_integration_test.go
+++ b/watcher/watcher_integration_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Watcher Integration", func() {
 			actualLRP1 = &models.ActualLRP{
 				ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
 				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", false, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 				State:                models.ActualLRPStateRunning,
 				ModificationTag:      *modTag,
 			}
@@ -139,7 +139,7 @@ var _ = Describe("Watcher Integration", func() {
 			removedActualLRP = &models.ActualLRP{
 				ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
 				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", false, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 				State:                models.ActualLRPStateRunning,
 				ModificationTag:      *modTag,
 			}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Watcher", func() {
 			ActualLRPNetInfo: models.NewActualLRPNetInfo(
 				hostAddress,
 				instanceAddress,
+				false,
 				models.NewPortMapping(hostPort, containerPort),
 			),
 			State: models.ActualLRPStateRunning,
@@ -413,21 +414,21 @@ var _ = Describe("Watcher", func() {
 		actualLRP1 := &models.ActualLRP{
 			ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
 			ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", false, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 			State:                models.ActualLRPStateRunning,
 		}
 
 		actualLRP2 := &models.ActualLRP{
 			ActualLRPKey:         models.NewActualLRPKey("pg-2", 0, "domain"),
 			ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint2.InstanceGUID, "cell-id"),
-			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint2.Host, "container-ip", models.NewPortMapping(endpoint2.Port, endpoint2.ContainerPort)),
+			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint2.Host, "container-ip", false, models.NewPortMapping(endpoint2.Port, endpoint2.ContainerPort)),
 			State:                models.ActualLRPStateRunning,
 		}
 
 		actualLRP3 := &models.ActualLRP{
 			ActualLRPKey:         models.NewActualLRPKey("pg-3", 1, "domain"),
 			ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint3.InstanceGUID, "cell-id"),
-			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint3.Host, "container-ip", models.NewPortMapping(endpoint3.Port, endpoint3.ContainerPort)),
+			ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint3.Host, "container-ip", false, models.NewPortMapping(endpoint3.Port, endpoint3.ContainerPort)),
 			State:                models.ActualLRPStateRunning,
 		}
 


### PR DESCRIPTION
#### PRs
This is a comprehensive set of PRs that must be merged at the same:

- [bbs](https://github.com/cloudfoundry/bbs/pull/39)
- [diego-ssh](https://github.com/cloudfoundry/diego-ssh/pull/45)
- [executor](https://github.com/cloudfoundry/executor/pull/46)
- [rep](https://github.com/cloudfoundry/rep/pull/28)
- [route-emitter](https://github.com/cloudfoundry/route-emitter/pull/14)

#### Changes

This change enables `rep` to advertise connection preference: Diego cell IP vs Instance (Container) IP.

Silk, the default container network plugin, prefers connecting to the Diego cell's IP address, and that's the default behavior.

Third party network plugins will now have the option to advertise the instance (container) IP address when they are placed on a separate overlay network.

To enable this behavior, set the `rep` BOSH job property `advertise_preference_for_instance_address` to true to direct `cf ssh` to use instance IP address.

This is a more fine-grained version of the `ssh-proxy` BOSH job property, `connect_to_instance_address`, which, when set to `true`, directs _all_ `cf ssh` connections to the instance's IP address, which is the desired behavior when _all_ instances are on the overlay network.

Fine-grained control is required for networks where not all instances are on the overlay networks, for example, networks with a mixture of Linux and Windows Diego cells.

By setting the preference for instance addresses on each `rep` job, heterogenous deployments can specify the the best/accessible address on the BOSH instance group level, allowing Linux cells to elect connecting to instance addresses and vice versa.

### Necessary Changes to `diego-release`

In addition to re-submoduling the repos with PRs, the following patch should be applied to `diego-release` to expose the property:

```diff
diff --git a/jobs/rep/spec b/jobs/rep/spec
index 4ce258dfb..7a33f3b16 100644
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -91,6 +91,9 @@ properties:
   diego.rep.listen_addr_securable:
     description: "address where rep listens for LRP and task start auction requests"
     default: "0.0.0.0:1801"
+  diego.rep.advertise_preference_for_instance_address:
+    description: "advertise that containers managed by this rep are directly accessible on the infrastructure network at their instance address. Components like ssh-proxy or routers may use this property when determining how to connect to a container. Set this flag only when using a third-party container-networking solution that provides direct connectivity between containers and VMs"
+    default: false

   diego.ssl.skip_cert_verify:
     description: "when connecting over https, ignore bad ssl certificates"
diff --git a/jobs/rep/templates/rep.json.erb b/jobs/rep/templates/rep.json.erb
index e2d5f14ac..247cf0e6a 100644
--- a/jobs/rep/templates/rep.json.erb
+++ b/jobs/rep/templates/rep.json.erb
@@ -45,6 +45,7 @@
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
     container_proxy_ads_addresses: p("containers.proxy.ads_addresses"),
+    advertise_preference_for_instance_address: p("diego.rep.advertise_preference_for_instance_address"),
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/proxy",
diff --git a/jobs/rep_windows/spec b/jobs/rep_windows/spec
index f08581e4d..5c617f380 100644
--- a/jobs/rep_windows/spec
+++ b/jobs/rep_windows/spec
@@ -87,6 +87,9 @@ properties:
   diego.rep.listen_addr_securable:
     description: "address where rep listens for LRP and task start auction requests"
     default: "0.0.0.0:1801"
+  diego.rep.advertise_preference_for_instance_address:
+    description: "advertise that containers managed by this rep are directly accessible on the infrastructure network at their instance address. Components like ssh-proxy or routers may use this property when determining how to connect to a container. Set this flag only when using a third-party container-networking solution that provides direct connectivity between containers and VMs"
+    default: false

   diego.ssl.skip_cert_verify:
     description: "when connecting over https, ignore bad ssl certificates"
diff --git a/jobs/rep_windows/templates/rep.json.erb b/jobs/rep_windows/templates/rep.json.erb
index 17a17dd32..923c6526e 100644
--- a/jobs/rep_windows/templates/rep.json.erb
+++ b/jobs/rep_windows/templates/rep.json.erb
@@ -45,6 +45,7 @@
     container_proxy_trusted_ca_certs: p("containers.proxy.trusted_ca_certificates"),
     container_proxy_verify_subject_alt_name: p("containers.proxy.verify_subject_alt_name"),
     container_proxy_ads_addresses: p("containers.proxy.ads_addresses"),
+    advertise_preference_for_instance_address: p("diego.rep.advertise_preference_for_instance_address"),
     enable_unproxied_port_mappings: p("containers.proxy.enable_unproxied_port_mappings"),
     proxy_memory_allocation_mb: p("containers.proxy.additional_memory_allocation_mb"),
     container_proxy_path: "/var/vcap/packages/envoy_windows",
```

CC @cunnie @evanfarrar