### PR TITLE
Ignore route service url in registry message hashing

### DIFF
--- a/routingtable/registry_message.go
+++ b/routingtable/registry_message.go
@@ -13,7 +13,7 @@ type RegistryMessage struct {
 	TlsPort              uint32            `json:"tls_port,omitempty"`
 	URIs                 []string          `json:"uris"`
 	App                  string            `json:"app,omitempty" hash:"ignore"`
-	RouteServiceUrl      string            `json:"route_service_url,omitempty"`
+	RouteServiceUrl      string            `json:"route_service_url,omitempty" hash:"ignore"`
 	PrivateInstanceId    string            `json:"private_instance_id,omitempty" hash:"ignore"`
 	PrivateInstanceIndex string            `json:"private_instance_index,omitempty" hash:"ignore"`
 	ServerCertDomainSAN  string            `json:"server_cert_domain_san,omitempty" hash:"ignore"`

--- a/unregistration/cache_test.go
+++ b/unregistration/cache_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Cache", func() {
 			registryMessage2.ServerCertDomainSAN = "some-unique-cert-domain-san"
 			registryMessage2.IsolationSegment = "some-unique-isolation-segment"
 			registryMessage2.EndpointUpdatedAtNs = 999
+			registryMessage2.RouteServiceUrl = "some-unique-route-service-url"
 			registryMessage2.Tags = map[string]string{"foo": "some-unique-tag"}
 
 			err := cache.Add([]routingtable.RegistryMessage{
@@ -114,6 +115,7 @@ var _ = Describe("Cache", func() {
 			registryMessage2.ServerCertDomainSAN = "some-unique-cert-domain-san"
 			registryMessage2.IsolationSegment = "some-unique-isolation-segment"
 			registryMessage2.EndpointUpdatedAtNs = 999
+			registryMessage2.RouteServiceUrl = "some-unique-route-service-url"
 			registryMessage2.Tags = map[string]string{"foo": "some-unique-tag"}
 
 			err := cache.Add([]routingtable.RegistryMessage{


### PR DESCRIPTION
### What is this change about?

- route service urls should not be used to differentiate unregistration
  messages
- if a route service is bound and then unbound, the updated LRP has the
  route service URL set to empty
  - when a route service is rebound to that LRP, the hashed registry
    message appears to the cache to be different than the existing
    record that tells the route emitter to continue to emit
    unregistration messages
  - instead, this change ensures any change for an app route update that
    changes the route service uri can invalidate the unregistration
    cache

### What problem it is trying to solve?

See: https://github.com/cloudfoundry/diego-release/issues/500

### What is the impact if the change is not made?

Binding and unbinding route services to apps causes app downtime

### How should this change be described in diego-release release notes?

Ensure unbinding and binding a route service stops repeated route unregistration messages to be sent to prevent app downtime