### PR TITLE
Switch to go-uaa from uaa-go-client

### DIFF
--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -538,7 +538,7 @@ var _ = Describe("Route Emitter", func() {
 				It("fails", func() {
 					Eventually(emitter.Wait()).Should(Receive())
 					Expect(runner.ExitCode()).NotTo(Equal(0))
-					Expect(runner).To(gbytes.Say("initialize-token-fetcher-error"))
+					Expect(runner).To(gbytes.Say("failed-parsing-uaa-host"))
 				})
 			})
 
@@ -625,7 +625,6 @@ var _ = Describe("Route Emitter", func() {
 
 					It("the emitter fails to fetch a token and does not start", func() {
 						Expect(runner).To(gbytes.Say("failed-fetching-uaa-key"))
-						Expect(runner).To(gbytes.Say("Client.Timeout"))
 						Expect(runner).ToNot(gbytes.Say("emitter1.started"))
 					})
 				})
@@ -655,7 +654,7 @@ var _ = Describe("Route Emitter", func() {
 			})
 
 			It("starts successfully without oauth config", func() {
-				Expect(runner).To(gbytes.Say("creating-noop-uaa-client"))
+				Expect(runner).To(gbytes.Say("using-noop-token-fetcher"))
 			})
 
 			Context("and the initial sync loop is finished", func() {


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

uaa-go-client is deprecated and it is recommended to switch to go-uaa

### How should this change be described in diego-release release notes?

Switched to [go-uaa](https://github.com/cloudfoundry-community/go-uaa) client library

### Please provide any contextual information.

Once this is merged, diego-release submodule can be bumped, with go mod vendor and submodule sync

Thank you!
