### PR TITLE
Use routing info bbs endpoint when syncing

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -356,9 +356,13 @@ func (w *Watcher) checkForEvents(resubscribeChannel chan error, eventChan chan m
 
 func getDesiredLRPs(logger lager.Logger, bbsClient bbs.Client, guids []string) ([]*models.DesiredLRP, error) {
 	logger.Debug("getting-desired-lrps-routing-info", lager.Data{"guids-length": len(guids)})
-	desiredLRPs, err := bbsClient.DesiredLRPRoutingInfos(logger, models.DesiredLRPFilter{
-		ProcessGuids: guids,
-	})
+	filter := models.DesiredLRPFilter{ProcessGuids: guids}
+
+	desiredLRPs, err := bbsClient.DesiredLRPRoutingInfos(logger, filter)
+	if err == bbs.EndpointNotFoundErr {
+		desiredLRPs, err = bbsClient.DesiredLRPs(logger, filter)
+	}
+
 	if err != nil {
 		logger.Error("failed-getting-desired-lrps-routing-info", err)
 		return nil, err

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -355,15 +355,15 @@ func (w *Watcher) checkForEvents(resubscribeChannel chan error, eventChan chan m
 }
 
 func getDesiredLRPs(logger lager.Logger, bbsClient bbs.Client, guids []string) ([]*models.DesiredLRP, error) {
-	logger.Debug("getting-desired-lrps", lager.Data{"guids-length": len(guids)})
-	desiredLRPs, err := bbsClient.DesiredLRPs(logger, models.DesiredLRPFilter{
+	logger.Debug("getting-desired-lrps-routing-info", lager.Data{"guids-length": len(guids)})
+	desiredLRPs, err := bbsClient.DesiredLRPRoutingInfos(logger, models.DesiredLRPFilter{
 		ProcessGuids: guids,
 	})
 	if err != nil {
-		logger.Error("failed-getting-desired-lrps", err)
+		logger.Error("failed-getting-desired-lrps-routing-info", err)
 		return nil, err
 	}
 
-	logger.Debug("succeeded-getting-desired-lrps", lager.Data{"num-desired-responses": len(desiredLRPs)})
+	logger.Debug("succeeded-getting-desired-lrps-routing-info", lager.Data{"num-desired-responses": len(desiredLRPs)})
 	return desiredLRPs, nil
 }

--- a/watcher/watcher_integration_test.go
+++ b/watcher/watcher_integration_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Watcher Integration", func() {
 				}, nil
 			}
 
-			bbsClient.DesiredLRPsStub = func(logger lager.Logger, f models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
+			bbsClient.DesiredLRPRoutingInfosStub = func(logger lager.Logger, f models.DesiredLRPFilter) ([]*models.DesiredLRP, error) {
 				defer GinkgoRecover()
 				return []*models.DesiredLRP{desiredLRP1}, nil
 			}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -740,7 +740,6 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("gets all the desired lrps", func() {
-				Eventually(bbsClient.DesiredLRPsCallCount).Should(Equal(0))
 				Eventually(bbsClient.DesiredLRPRoutingInfosCallCount).Should(Equal(1))
 				_, filter := bbsClient.DesiredLRPRoutingInfosArgsForCall(0)
 				Expect(filter.ProcessGuids).To(BeEmpty())


### PR DESCRIPTION
This PR is related to this issue: https://github.com/cloudfoundry/diego-release/issues/678. Here we change the bbs endpoint used to retrieve the desiredLRP's when syncing. We receive a desiredLRP structure with only the needed information for the route emitter. 