### PR TITLE
Only add endpoint for Routable LRP

### DIFF
--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Route Emitter", func() {
 							lrpKey := models.NewActualLRPKey("some-guid", 0, domain)
 							instanceKey := models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 							netInfo := models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(62003, 5222))
-							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 						})
 
 						It("requests a token from the server", func() {
@@ -583,7 +583,6 @@ var _ = Describe("Route Emitter", func() {
 							}, 5*time.Second).Should(ContainElement("/oauth/token"))
 						})
 					})
-
 				}
 
 				BeforeEach(func() {
@@ -708,7 +707,7 @@ var _ = Describe("Route Emitter", func() {
 							lrpKey = models.NewActualLRPKey(processGUID, 0, domain)
 							instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 							netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(5222, 5222))
-							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 							Eventually(runner).Should(gbytes.Say("caching-event"))
 
 							By("unblocking the sync loop")
@@ -764,7 +763,7 @@ var _ = Describe("Route Emitter", func() {
 					})
 
 					JustBeforeEach(func() {
-						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 					})
 
 					It("emits its routes immediately", func() {
@@ -953,7 +952,7 @@ var _ = Describe("Route Emitter", func() {
 						lrpKey = models.NewActualLRPKey(expectedTCPProcessGUID, 0, domain)
 						instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(5222, 5222))
-						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 						Eventually(runner).Should(gbytes.Say("caching-event"))
 
 						By("unblocking the sync loop")
@@ -989,7 +988,7 @@ var _ = Describe("Route Emitter", func() {
 					key := models.NewActualLRPKey("some-guid-1", 0, domain)
 					instanceKey := models.NewActualLRPInstanceKey("instance-guid-1", "cell-id")
 					netInfo := models.NewActualLRPNetInfo("some-ip-1", "container-ip-1", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(62003, 1883))
-					Expect(bbsClient.StartActualLRP(logger, "", &key, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+					Expect(bbsClient.StartActualLRP(logger, "", &key, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 				})
 
 				It("starts an SSE connection to the bbs and continues to try to emit to routing api", func() {
@@ -1243,7 +1242,7 @@ var _ = Describe("Route Emitter", func() {
 			It("emits routes", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 				Expect(err).NotTo(HaveOccurred())
 				var msg1, msg2 routingtable.RegistryMessage
 				Eventually(registeredRoutes).Should(Receive(&msg1))
@@ -1331,7 +1330,7 @@ var _ = Describe("Route Emitter", func() {
 
 			Context("and an instance starts", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1372,7 +1371,7 @@ var _ = Describe("Route Emitter", func() {
 						sqlRunner.Reset()
 
 						// Only start actual LRP, do not repopulate Desired
-						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -1631,7 +1630,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1792,7 +1791,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("does not emit any internal routes", func() {
@@ -1840,7 +1839,7 @@ var _ = Describe("Route Emitter", func() {
 
 			Context("and an instance starts", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1878,7 +1877,7 @@ var _ = Describe("Route Emitter", func() {
 						Eventually(runner).Should(gbytes.Say("succeeded-getting-desired-lrps"))
 
 						// Only start actual LRP, do not repopulate Desired
-						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -1965,7 +1964,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -2068,7 +2067,7 @@ var _ = Describe("Route Emitter", func() {
 			err := bbsClient.DesireLRP(logger, "", desiredLRP)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})
+			err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -2294,7 +2293,7 @@ var _ = Describe("Route Emitter", func() {
 					lrpKey := models.NewActualLRPKey("some-other-guid", 0, domain)
 					instanceKey := models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 					netInfo := models.NewActualLRPNetInfo("1.2.3.4", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(65100, 8080))
-					Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+					Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 
 					// keep reading unregistration messages until route-1 is re-registered
 					done := make(chan struct{})
@@ -2368,7 +2367,7 @@ var _ = Describe("Route Emitter", func() {
 			runner.StartCheck = "succeeded-getting-actual-lrps"
 			emitter = ginkgomon.Invoke(runner)
 
-			Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{})).To(Succeed())
+			Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
 			Eventually(runner).Should(gbytes.Say("caching-event"))
 
 			By("unblocking the sync loop")

--- a/routehandlers/handler.go
+++ b/routehandlers/handler.go
@@ -263,7 +263,12 @@ func (handler *Handler) handleActualUpdate(logger lager.Logger, before, after *m
 	)
 	switch {
 	case after.State == models.ActualLRPStateRunning:
-		routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(logger, after)
+		if after.Routable == true {
+			routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(logger, after)
+		} else if before.Routable == true {
+			routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(logger, after)
+		}
+
 		if before.State == models.ActualLRPStateRunning &&
 			before.Presence == models.ActualLRP_Ordinary && after.Presence == models.ActualLRP_Evacuating {
 			removeRouteMappings, removeMessagesToEmit := handler.routingTable.RemoveEndpoint(logger, before)

--- a/routehandlers/handler.go
+++ b/routehandlers/handler.go
@@ -263,9 +263,9 @@ func (handler *Handler) handleActualUpdate(logger lager.Logger, before, after *m
 	)
 	switch {
 	case after.State == models.ActualLRPStateRunning:
-		if after.Routable == true {
+		if !after.RoutableExists() || after.GetRoutable() == true {
 			routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(logger, after)
-		} else if before.Routable == true {
+		} else if before.GetRoutable() == true {
 			routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(logger, after)
 		}
 

--- a/routehandlers/handler.go
+++ b/routehandlers/handler.go
@@ -278,7 +278,13 @@ func (handler *Handler) handleActualUpdate(logger lager.Logger, before, after *m
 	case before.State == models.ActualLRPStateRunning && after.State != models.ActualLRPStateRunning:
 		routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(logger, before)
 	}
-	err := handler.unregistrationCache.Remove(messagesToEmit.RegistrationMessages)
+
+	err := handler.unregistrationCache.Add(messagesToEmit.UnregistrationMessages)
+	if err != nil {
+		return err
+	}
+
+	err = handler.unregistrationCache.Remove(messagesToEmit.RegistrationMessages)
 	if err != nil {
 		return err
 	}

--- a/routehandlers/handler_test.go
+++ b/routehandlers/handler_test.go
@@ -501,6 +501,7 @@ var _ = Describe("Handler", func() {
 
 				BeforeEach(func() {
 					fakeTable.AddEndpointReturns(emptyTCPRouteMappings, dummyMessagesToEmit)
+					fakeTable.RemoveEndpointReturns(emptyTCPRouteMappings, dummyMessagesToEmit)
 
 					beforeActualLRP = &models.ActualLRP{
 						ActualLRPKey:         models.NewActualLRPKey(expectedProcessGuid, expectedIndex, "domain"),
@@ -517,40 +518,13 @@ var _ = Describe("Handler", func() {
 							models.NewPortMapping(expectedExternalPort, expectedContainerPort),
 							models.NewPortMapping(expectedAdditionalExternalPort, expectedAdditionalContainerPort),
 						),
-						State: models.ActualLRPStateRunning,
+						State:    models.ActualLRPStateRunning,
+						Routable: true,
 					}
 				})
 
 				JustBeforeEach(func() {
 					routeHandler.HandleEvent(logger, models.NewActualLRPInstanceChangedEvent(beforeActualLRP, afterActualLRP, "some-trace-id"))
-				})
-
-				It("should add/update the endpoint on the table", func() {
-					Expect(fakeTable.AddEndpointCallCount()).To(Equal(1))
-
-					_, actualLRP := fakeTable.AddEndpointArgsForCall(0)
-					Expect(actualLRP).To(Equal(afterActualLRP))
-				})
-
-				It("should emit whatever the table tells it to emit", func() {
-					Expect(natsEmitter.EmitCallCount()).Should(Equal(1))
-
-					messagesToEmit := natsEmitter.EmitArgsForCall(0)
-					Expect(messagesToEmit).To(Equal(dummyMessagesToEmit))
-				})
-
-				It("sends a 'routes registered' metric", func() {
-					Eventually(counterChan).Should(Receive(Equal(counter{
-						name:  "RoutesRegistered",
-						delta: 2,
-					})))
-				})
-
-				It("sends a 'routes unregistered' metric", func() {
-					Eventually(counterChan).Should(Receive(Equal(counter{
-						name:  "RoutesUnregistered",
-						delta: 0,
-					})))
 				})
 
 				Context("when one or all the LRP are nil", func() {
@@ -568,10 +542,92 @@ var _ = Describe("Handler", func() {
 						JustBeforeEach(func() {
 							afterActualLRP = nil
 						})
+
 						It("logs an error", func() {
 							routeHandler.HandleEvent(logger, models.NewActualLRPInstanceChangedEvent(beforeActualLRP, afterActualLRP, "some-trace-id"))
 							Expect(logger).To(gbytes.Say("nil-actual-lrp"))
 						})
+					})
+				})
+
+				Context("when after state Routable is true", func() {
+					BeforeEach(func() {
+						afterActualLRP.Routable = true
+					})
+
+					It("should add/update the endpoint on the table", func() {
+						Expect(fakeTable.AddEndpointCallCount()).To(Equal(1))
+
+						_, actualLRP := fakeTable.AddEndpointArgsForCall(0)
+						Expect(actualLRP).To(Equal(afterActualLRP))
+					})
+
+					It("should emit whatever the table tells it to emit", func() {
+						Expect(natsEmitter.EmitCallCount()).Should(Equal(1))
+
+						messagesToEmit := natsEmitter.EmitArgsForCall(0)
+						Expect(messagesToEmit).To(Equal(dummyMessagesToEmit))
+					})
+
+					It("sends a 'routes registered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesRegistered",
+							delta: 2,
+						})))
+					})
+
+					It("sends a 'routes unregistered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesUnregistered",
+							delta: 0,
+						})))
+					})
+				})
+
+				Context("when after state Routable is false and before state Routable is true", func() {
+					BeforeEach(func() {
+						beforeActualLRP.Routable = true
+						afterActualLRP.Routable = false
+					})
+
+					It("should not add/update the endpoint on the table", func() {
+						Expect(fakeTable.AddEndpointCallCount()).To(Equal(0))
+					})
+
+					It("should remove the endpoint from the table", func() {
+						Expect(fakeTable.RemoveEndpointCallCount()).To(Equal(1))
+
+						_, actualLRP := fakeTable.RemoveEndpointArgsForCall(0)
+						Expect(actualLRP).To(Equal(afterActualLRP))
+					})
+
+					It("should emit whatever the table tells it to emit", func() {
+						Expect(natsEmitter.EmitCallCount()).To(Equal(1))
+
+						messagesToEmit := natsEmitter.EmitArgsForCall(0)
+						Expect(messagesToEmit).To(Equal(dummyMessagesToEmit))
+					})
+				})
+
+				Context("when after state Routable is false and before state Routable is false", func() {
+					BeforeEach(func() {
+						beforeActualLRP.Routable = false
+						afterActualLRP.Routable = false
+					})
+
+					It("should not add/update the endpoint on the table", func() {
+						Expect(fakeTable.AddEndpointCallCount()).To(Equal(0))
+					})
+
+					It("should not remove the endpoint from the table", func() {
+						Expect(fakeTable.RemoveEndpointCallCount()).To(Equal(0))
+					})
+
+					It("should call emit with empty messages", func() {
+						Expect(natsEmitter.EmitCallCount()).To(Equal(1))
+
+						messagesToEmit := natsEmitter.EmitArgsForCall(0)
+						Expect(messagesToEmit).To(Equal(routingtable.MessagesToEmit{RegistrationMessages: nil}))
 					})
 				})
 
@@ -679,11 +735,13 @@ var _ = Describe("Handler", func() {
 						ActualLRPInstanceKey: models.NewActualLRPInstanceKey(expectedInstanceGUID, "cell-id"),
 						State:                models.ActualLRPStateRunning,
 						Presence:             models.ActualLRP_Ordinary,
+						Routable:             true,
 					}
 					afterActualLRP = &models.ActualLRP{
 						ActualLRPKey:         models.NewActualLRPKey(expectedProcessGuid, expectedIndex, "domain"),
 						ActualLRPInstanceKey: models.NewActualLRPInstanceKey(expectedInstanceGUID, "cell-id"),
 						State:                models.ActualLRPStateRunning,
+						Routable:             true,
 					}
 				})
 

--- a/routehandlers/handler_test.go
+++ b/routehandlers/handler_test.go
@@ -607,6 +607,20 @@ var _ = Describe("Handler", func() {
 						messagesToEmit := natsEmitter.EmitArgsForCall(0)
 						Expect(messagesToEmit).To(Equal(dummyMessagesToEmit))
 					})
+
+					It("sends a 'routes registered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesRegistered",
+							delta: 2,
+						})))
+					})
+
+					It("sends a 'routes unregistered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesUnregistered",
+							delta: 0,
+						})))
+					})
 				})
 
 				Context("when after state Routable is false and before state Routable is false", func() {
@@ -628,6 +642,20 @@ var _ = Describe("Handler", func() {
 
 						messagesToEmit := natsEmitter.EmitArgsForCall(0)
 						Expect(messagesToEmit).To(Equal(routingtable.MessagesToEmit{RegistrationMessages: nil}))
+					})
+
+					It("sends a 'routes registered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesRegistered",
+							delta: 0,
+						})))
+					})
+
+					It("sends a 'routes unregistered' metric", func() {
+						Eventually(counterChan).Should(Receive(Equal(counter{
+							name:  "RoutesUnregistered",
+							delta: 0,
+						})))
 					})
 				})
 

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -265,21 +265,27 @@ var _ = Describe("RoutingAPIHandler", func() {
 					}
 				})
 
-				It("invokes AddEndpoint on RoutingTable", func() {
-					Expect(fakeRoutingTable.AddEndpointCallCount()).Should(Equal(1))
-					_, lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
-					Expect(lrp).Should(Equal(afterLRP))
-				})
-
-				Context("when there are routing events", func() {
+				Context("when Routable is true", func() {
 					BeforeEach(func() {
-						fakeRoutingTable.AddEndpointReturns(routingEvents, emptyNatsMessages)
+						afterLRP.Routable = true
 					})
 
-					It("invokes Emit on Emitter", func() {
-						Expect(fakeRoutingAPIEmitter.EmitCallCount()).Should(Equal(1))
-						events := fakeRoutingAPIEmitter.EmitArgsForCall(0)
-						Expect(events).Should(Equal(routingEvents))
+					It("invokes AddEndpoint on RoutingTable", func() {
+						Expect(fakeRoutingTable.AddEndpointCallCount()).Should(Equal(1))
+						_, lrp := fakeRoutingTable.AddEndpointArgsForCall(0)
+						Expect(lrp).Should(Equal(afterLRP))
+					})
+
+					Context("when there are routing events", func() {
+						BeforeEach(func() {
+							fakeRoutingTable.AddEndpointReturns(routingEvents, emptyNatsMessages)
+						})
+
+						It("invokes Emit on Emitter", func() {
+							Expect(fakeRoutingAPIEmitter.EmitCallCount()).Should(Equal(1))
+							events := fakeRoutingAPIEmitter.EmitArgsForCall(0)
+							Expect(events).Should(Equal(routingEvents))
+						})
 					})
 				})
 			})

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -267,7 +267,7 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				Context("when Routable is true", func() {
 					BeforeEach(func() {
-						afterLRP.Routable = true
+						afterLRP.SetRoutable(true)
 					})
 
 					It("invokes AddEndpoint on RoutingTable", func() {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -267,7 +267,7 @@ func (w *Watcher) sync(logger lager.Logger, ch chan<- *syncEventResult) {
 		logger.Debug("succeeded-getting-actual-lrps", lager.Data{"num-actual-responses": len(actualLRPs)})
 
 		for _, actualLRP := range actualLRPs {
-			if actualLRP.State == models.ActualLRPStateRunning {
+			if actualLRP.State == models.ActualLRPStateRunning && (!actualLRP.RoutableExists() || actualLRP.GetRoutable() == true) {
 				runningActualLRPs = append(runningActualLRPs, actualLRP)
 			}
 		}


### PR DESCRIPTION
### What is this change about?

As part of readiness health checks work route emitter should only add endpoint for routes that are Routable.

This PR accompanies [executor PR](https://github.com/cloudfoundry/executor/pull/82) Once executor emits ContainerRunning event rep will send information to BBS in StartActualLRP call, which would include information whether the container is routable.

### How should this change be described in diego-release release notes?

Support readiness health checks

### Please provide any contextual information.

[RFC](https://github.com/cloudfoundry/community/pull/630)

Thank you!