### PR TITLE
Add AZ to registry message

### DIFF
--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Route Emitter", func() {
 							lrpKey := models.NewActualLRPKey("some-guid", 0, domain)
 							instanceKey := models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 							netInfo := models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(62003, 5222))
-							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 						})
 
 						It("requests a token from the server", func() {
@@ -707,7 +707,7 @@ var _ = Describe("Route Emitter", func() {
 							lrpKey = models.NewActualLRPKey(processGUID, 0, domain)
 							instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 							netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(5222, 5222))
-							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+							Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 							Eventually(runner).Should(gbytes.Say("caching-event"))
 
 							By("unblocking the sync loop")
@@ -763,7 +763,7 @@ var _ = Describe("Route Emitter", func() {
 					})
 
 					JustBeforeEach(func() {
-						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 					})
 
 					It("emits its routes immediately", func() {
@@ -952,7 +952,7 @@ var _ = Describe("Route Emitter", func() {
 						lrpKey = models.NewActualLRPKey(expectedTCPProcessGUID, 0, domain)
 						instanceKey = models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 						netInfo = models.NewActualLRPNetInfo("some-ip", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(5222, 5222))
-						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+						Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 						Eventually(runner).Should(gbytes.Say("caching-event"))
 
 						By("unblocking the sync loop")
@@ -988,7 +988,7 @@ var _ = Describe("Route Emitter", func() {
 					key := models.NewActualLRPKey("some-guid-1", 0, domain)
 					instanceKey := models.NewActualLRPInstanceKey("instance-guid-1", "cell-id")
 					netInfo := models.NewActualLRPNetInfo("some-ip-1", "container-ip-1", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(62003, 1883))
-					Expect(bbsClient.StartActualLRP(logger, "", &key, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+					Expect(bbsClient.StartActualLRP(logger, "", &key, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 				})
 
 				It("starts an SSE connection to the bbs and continues to try to emit to routing api", func() {
@@ -1242,7 +1242,7 @@ var _ = Describe("Route Emitter", func() {
 			It("emits routes", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 				Expect(err).NotTo(HaveOccurred())
 				var msg1, msg2 routingtable.RegistryMessage
 				Eventually(registeredRoutes).Should(Receive(&msg1))
@@ -1262,6 +1262,7 @@ var _ = Describe("Route Emitter", func() {
 							"component": "route-emitter",
 							"some-tag":  "some-value",
 						},
+						AvailabilityZone: "some-zone",
 					}),
 					MatchRegistryMessage(routingtable.RegistryMessage{
 						URIs:                 []string{hostnames[0]},
@@ -1276,6 +1277,7 @@ var _ = Describe("Route Emitter", func() {
 							"component": "route-emitter",
 							"some-tag":  "some-value",
 						},
+						AvailabilityZone: "some-zone",
 					}),
 				))
 			})
@@ -1330,7 +1332,7 @@ var _ = Describe("Route Emitter", func() {
 
 			Context("and an instance starts", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1371,7 +1373,7 @@ var _ = Describe("Route Emitter", func() {
 						sqlRunner.Reset()
 
 						// Only start actual LRP, do not repopulate Desired
-						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -1399,6 +1401,7 @@ var _ = Describe("Route Emitter", func() {
 								"component": "route-emitter",
 								"some-tag":  "some-value",
 							},
+							AvailabilityZone: "some-zone",
 						}),
 						MatchRegistryMessage(routingtable.RegistryMessage{
 							URIs:                 []string{hostnames[0]},
@@ -1413,6 +1416,7 @@ var _ = Describe("Route Emitter", func() {
 								"component": "route-emitter",
 								"some-tag":  "some-value",
 							},
+							AvailabilityZone: "some-zone",
 						}),
 					))
 				})
@@ -1442,6 +1446,7 @@ var _ = Describe("Route Emitter", func() {
 									"component": "route-emitter",
 									"some-tag":  "some-value",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 							MatchRegistryMessage(routingtable.RegistryMessage{
 								URIs:                 []string{hostnames[0]},
@@ -1457,6 +1462,7 @@ var _ = Describe("Route Emitter", func() {
 									"component": "route-emitter",
 									"some-tag":  "some-value",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 						))
 					})
@@ -1488,6 +1494,7 @@ var _ = Describe("Route Emitter", func() {
 									"component": "route-emitter",
 									"some-tag":  "some-value",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 							MatchRegistryMessage(routingtable.RegistryMessage{
 								URIs:                 []string{hostnames[0]},
@@ -1502,6 +1509,7 @@ var _ = Describe("Route Emitter", func() {
 									"component": "route-emitter",
 									"some-tag":  "some-value",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 						))
 					})
@@ -1531,6 +1539,7 @@ var _ = Describe("Route Emitter", func() {
 										"component": "route-emitter",
 										"some-tag":  "some-value",
 									},
+									AvailabilityZone: "some-zone",
 								}),
 								MatchRegistryMessage(routingtable.RegistryMessage{
 									URIs:                 []string{hostnames[0]},
@@ -1546,6 +1555,7 @@ var _ = Describe("Route Emitter", func() {
 										"component": "route-emitter",
 										"some-tag":  "some-value",
 									},
+									AvailabilityZone: "some-zone",
 								}),
 							))
 						})
@@ -1575,6 +1585,7 @@ var _ = Describe("Route Emitter", func() {
 											"component": "route-emitter",
 											"some-tag":  "some-value",
 										},
+										AvailabilityZone: "some-zone",
 									}),
 									MatchRegistryMessage(routingtable.RegistryMessage{
 										URIs:                 []string{hostnames[0]},
@@ -1590,6 +1601,7 @@ var _ = Describe("Route Emitter", func() {
 											"component": "route-emitter",
 											"some-tag":  "some-value",
 										},
+										AvailabilityZone: "some-zone",
 									}),
 								))
 							})
@@ -1630,7 +1642,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1662,6 +1674,7 @@ var _ = Describe("Route Emitter", func() {
 								"component": "route-emitter",
 								"some-tag":  "some-value",
 							},
+							AvailabilityZone: "some-zone",
 						}),
 						MatchRegistryMessage(routingtable.RegistryMessage{
 							URIs:                 []string{hostnames[0]},
@@ -1676,6 +1689,7 @@ var _ = Describe("Route Emitter", func() {
 								"component": "route-emitter",
 								"some-tag":  "some-value",
 							},
+							AvailabilityZone: "some-zone",
 						}),
 					))
 				})
@@ -1791,7 +1805,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("does not emit any internal routes", func() {
@@ -1839,7 +1853,7 @@ var _ = Describe("Route Emitter", func() {
 
 			Context("and an instance starts", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+					err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -1877,7 +1891,7 @@ var _ = Describe("Route Emitter", func() {
 						Eventually(runner).Should(gbytes.Say("succeeded-getting-desired-lrps"))
 
 						// Only start actual LRP, do not repopulate Desired
-						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+						err := bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -1894,6 +1908,7 @@ var _ = Describe("Route Emitter", func() {
 								Tags: map[string]string{
 									"component": "route-emitter",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 							MatchRegistryMessage(routingtable.RegistryMessage{
 								URIs:                 []string{internalHostnames[0], fmt.Sprintf("%d.%s", 0, internalHostnames[0])},
@@ -1903,6 +1918,7 @@ var _ = Describe("Route Emitter", func() {
 								Tags: map[string]string{
 									"component": "route-emitter",
 								},
+								AvailabilityZone: "some-zone",
 							}),
 						))
 					})
@@ -1920,6 +1936,7 @@ var _ = Describe("Route Emitter", func() {
 							PrivateInstanceIndex: "0",
 							App:                  desiredLRP.LogGuid,
 							Tags:                 map[string]string{"component": "route-emitter"},
+							AvailabilityZone:     "some-zone",
 						}),
 						MatchRegistryMessage(routingtable.RegistryMessage{
 							URIs:                 []string{internalHostnames[0], fmt.Sprintf("%d.%s", 0, internalHostnames[0])},
@@ -1927,6 +1944,7 @@ var _ = Describe("Route Emitter", func() {
 							PrivateInstanceIndex: "0",
 							App:                  desiredLRP.LogGuid,
 							Tags:                 map[string]string{"component": "route-emitter"},
+							AvailabilityZone:     "some-zone",
 						}),
 					))
 				})
@@ -1964,7 +1982,7 @@ var _ = Describe("Route Emitter", func() {
 				err := bbsClient.DesireLRP(logger, "", desiredLRP)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+				err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -1989,6 +2007,7 @@ var _ = Describe("Route Emitter", func() {
 							PrivateInstanceIndex: "0",
 							App:                  desiredLRP.LogGuid,
 							Tags:                 map[string]string{"component": "route-emitter"},
+							AvailabilityZone:     "some-zone",
 						}),
 						MatchRegistryMessage(routingtable.RegistryMessage{
 							URIs:                 []string{internalHostnames[0], fmt.Sprintf("0.%s", internalHostnames[0])},
@@ -1996,6 +2015,7 @@ var _ = Describe("Route Emitter", func() {
 							PrivateInstanceIndex: "0",
 							App:                  desiredLRP.LogGuid,
 							Tags:                 map[string]string{"component": "route-emitter"},
+							AvailabilityZone:     "some-zone",
 						}),
 					))
 				})
@@ -2067,7 +2087,7 @@ var _ = Describe("Route Emitter", func() {
 			err := bbsClient.DesireLRP(logger, "", desiredLRP)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)
+			err = bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -2293,7 +2313,7 @@ var _ = Describe("Route Emitter", func() {
 					lrpKey := models.NewActualLRPKey("some-other-guid", 0, domain)
 					instanceKey := models.NewActualLRPInstanceKey("instance-guid", "cell-id")
 					netInfo := models.NewActualLRPNetInfo("1.2.3.4", "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(65100, 8080))
-					Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+					Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 
 					// keep reading unregistration messages until route-1 is re-registered
 					done := make(chan struct{})
@@ -2323,6 +2343,7 @@ var _ = Describe("Route Emitter", func() {
 							"component": "route-emitter",
 							"some-tag":  "some-value",
 						},
+						AvailabilityZone: "some-zone",
 					})))
 					done <- struct{}{}
 
@@ -2367,7 +2388,7 @@ var _ = Describe("Route Emitter", func() {
 			runner.StartCheck = "succeeded-getting-actual-lrps"
 			emitter = ginkgomon.Invoke(runner)
 
-			Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true)).To(Succeed())
+			Expect(bbsClient.StartActualLRP(logger, "", &lrpKey, &instanceKey, &netInfo, []*models.ActualLRPInternalRoute{}, map[string]string{}, true, "some-zone")).To(Succeed())
 			Eventually(runner).Should(gbytes.Say("caching-event"))
 
 			By("unblocking the sync loop")

--- a/routingtable/endpoint.go
+++ b/routingtable/endpoint.go
@@ -44,6 +44,7 @@ type Endpoint struct {
 	Since                 int64
 	ModificationTag       *models.ModificationTag
 	PreferredAddress      models.ActualLRPNetInfo_PreferredAddress
+	AvailabilityZone      string
 }
 
 func (e Endpoint) key() EndpointKey {
@@ -70,6 +71,7 @@ func NewEndpoint(
 	port, containerPort uint32,
 	preferredAddress models.ActualLRPNetInfo_PreferredAddress,
 	modificationTag *models.ModificationTag,
+	availabiltiyZone string,
 ) Endpoint {
 	return Endpoint{
 		InstanceGUID:     instanceGUID,
@@ -80,6 +82,7 @@ func NewEndpoint(
 		ContainerPort:    containerPort,
 		PreferredAddress: preferredAddress,
 		ModificationTag:  modificationTag,
+		AvailabilityZone: availabiltiyZone,
 	}
 }
 
@@ -226,6 +229,7 @@ func NewEndpointsFromActual(actualLRP *models.ActualLRP) []Endpoint {
 				ContainerTlsProxyPort: portMapping.ContainerTlsProxyPort,
 				Since:                 actualLRP.Since,
 				PreferredAddress:      actualLRP.PreferredAddress,
+				AvailabilityZone:      actualLRP.AvailabilityZone,
 			}
 			endpoints = append(endpoints, endpoint)
 		}

--- a/routingtable/endpoint_utils_test.go
+++ b/routingtable/endpoint_utils_test.go
@@ -64,16 +64,17 @@ var _ = Describe("LRP Utils", func() {
 						models.NewPortMapping(11, 44),
 						models.NewPortMapping(66, 99),
 					),
-					Presence:        models.ActualLRP_Ordinary,
-					State:           models.ActualLRPStateRunning,
-					ModificationTag: tag,
+					Presence:         models.ActualLRP_Ordinary,
+					State:            models.ActualLRPStateRunning,
+					ModificationTag:  tag,
+					AvailabilityZone: "some-zone",
 				}
 
 				endpoints := routingtable.NewEndpointsFromActual(actualInfo)
 
 				Expect(endpoints).To(ConsistOf([]routingtable.Endpoint{
-					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 11, 44, models.ActualLRPNetInfo_PreferredAddressHost, &tag),
-					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 66, 99, models.ActualLRPNetInfo_PreferredAddressHost, &tag),
+					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 11, 44, models.ActualLRPNetInfo_PreferredAddressHost, &tag, "some-zone"),
+					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 66, 99, models.ActualLRPNetInfo_PreferredAddressHost, &tag, "some-zone"),
 				}))
 			})
 
@@ -90,16 +91,17 @@ var _ = Describe("LRP Utils", func() {
 							models.NewPortMappingWithTLSProxy(11, 44, 61004, 61005),
 							models.NewPortMappingWithTLSProxy(66, 99, 61006, 61007),
 						),
-						Presence:        models.ActualLRP_Ordinary,
-						State:           models.ActualLRPStateRunning,
-						ModificationTag: tag,
+						Presence:         models.ActualLRP_Ordinary,
+						State:            models.ActualLRPStateRunning,
+						ModificationTag:  tag,
+						AvailabilityZone: "some-zone",
 					}
 
 					endpoints := routingtable.NewEndpointsFromActual(actualInfo)
 
 					Expect(endpoints).To(ConsistOf([]routingtable.Endpoint{
-						newEndpointWithTlsProxyPort("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 11, 44, 61004, 61005, models.ActualLRPNetInfo_PreferredAddressInstance, &tag),
-						newEndpointWithTlsProxyPort("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 66, 99, 61006, 61007, models.ActualLRPNetInfo_PreferredAddressInstance, &tag),
+						newEndpointWithTlsProxyPort("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 11, 44, 61004, 61005, models.ActualLRPNetInfo_PreferredAddressInstance, &tag, "some-zone"),
+						newEndpointWithTlsProxyPort("instance-guid", models.ActualLRP_Ordinary, "1.1.1.1", "2.2.2.2", 66, 99, 61006, 61007, models.ActualLRPNetInfo_PreferredAddressInstance, &tag, "some-zone"),
 					}))
 				})
 			})
@@ -119,16 +121,17 @@ var _ = Describe("LRP Utils", func() {
 						models.NewPortMapping(11, 44),
 						models.NewPortMapping(66, 99),
 					),
-					Presence:        models.ActualLRP_Evacuating,
-					State:           models.ActualLRPStateRunning,
-					ModificationTag: tag,
+					Presence:         models.ActualLRP_Evacuating,
+					State:            models.ActualLRPStateRunning,
+					ModificationTag:  tag,
+					AvailabilityZone: "some-zone",
 				}
 
 				endpoints := routingtable.NewEndpointsFromActual(actualInfo)
 
 				Expect(endpoints).To(ConsistOf([]routingtable.Endpoint{
-					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Evacuating, "1.1.1.1", "2.2.2.2", 11, 44, models.ActualLRPNetInfo_PreferredAddressHost, &tag),
-					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Evacuating, "1.1.1.1", "2.2.2.2", 66, 99, models.ActualLRPNetInfo_PreferredAddressHost, &tag),
+					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Evacuating, "1.1.1.1", "2.2.2.2", 11, 44, models.ActualLRPNetInfo_PreferredAddressHost, &tag, "some-zone"),
+					routingtable.NewEndpoint("instance-guid", models.ActualLRP_Evacuating, "1.1.1.1", "2.2.2.2", 66, 99, models.ActualLRPNetInfo_PreferredAddressHost, &tag, "some-zone"),
 				}))
 			})
 		})
@@ -241,6 +244,7 @@ func newEndpointWithTlsProxyPort(
 	port, containerPort, tlsProxyPort, containerTlsProxyPort uint32,
 	preferredAddress models.ActualLRPNetInfo_PreferredAddress,
 	modificationTag *models.ModificationTag,
+	availabiltiyZone string,
 ) routingtable.Endpoint {
 	return routingtable.Endpoint{
 		InstanceGUID:          instanceGUID,
@@ -253,5 +257,6 @@ func newEndpointWithTlsProxyPort(
 		ContainerTlsProxyPort: containerTlsProxyPort,
 		PreferredAddress:      preferredAddress,
 		ModificationTag:       modificationTag,
+		AvailabilityZone:      availabiltiyZone,
 	}
 }

--- a/routingtable/registry_message.go
+++ b/routingtable/registry_message.go
@@ -21,6 +21,7 @@ type RegistryMessage struct {
 	IsolationSegment     string            `json:"isolation_segment,omitempty" hash:"ignore"`
 	EndpointUpdatedAtNs  int64             `json:"endpoint_updated_at_ns,omitempty" hash:"ignore"`
 	Tags                 map[string]string `json:"tags,omitempty" hash:"ignore"`
+	AvailabilityZone     string            `json:"availability_zone,omitempty" hash:"ignore"`
 }
 
 func RegistryMessageFor(endpoint Endpoint, route Route, emitEndpointUpdatedAt bool) RegistryMessage {
@@ -42,6 +43,7 @@ func RegistryMessageFor(endpoint Endpoint, route Route, emitEndpointUpdatedAt bo
 		App:                 route.LogGUID,
 		IsolationSegment:    route.IsolationSegment,
 		Tags:                populateMetricTags(route.MetricTags, endpoint),
+		AvailabilityZone:    endpoint.AvailabilityZone,
 		EndpointUpdatedAtNs: since,
 
 		PrivateInstanceId:    endpoint.InstanceGUID,
@@ -70,6 +72,7 @@ func InternalAddressRegistryMessageFor(endpoint Endpoint, route Route, emitEndpo
 		App:              route.LogGUID,
 		IsolationSegment: route.IsolationSegment,
 		Tags:             populateMetricTags(route.MetricTags, endpoint),
+		AvailabilityZone: endpoint.AvailabilityZone,
 
 		ServerCertDomainSAN:  endpoint.InstanceGUID,
 		PrivateInstanceId:    endpoint.InstanceGUID,
@@ -94,6 +97,7 @@ func InternalEndpointRegistryMessageFor(endpoint Endpoint, route InternalRoute, 
 		Host:                endpoint.ContainerIP,
 		App:                 route.LogGUID,
 		Tags:                map[string]string{"component": "route-emitter"},
+		AvailabilityZone:    endpoint.AvailabilityZone,
 		EndpointUpdatedAtNs: since,
 
 		PrivateInstanceIndex: index,

--- a/routingtable/registry_message_test.go
+++ b/routingtable/registry_message_test.go
@@ -25,6 +25,7 @@ var _ = Describe("RegistryMessage", func() {
 			RouteServiceUrl:      "https://hello.com",
 			EndpointUpdatedAtNs:  1000,
 			Tags:                 map[string]string{"component": "route-emitter", "foo": "bar", "doo": "0", "goo": "instance-guid"},
+			AvailabilityZone:     "some-zone",
 		}
 	})
 
@@ -42,7 +43,8 @@ var _ = Describe("RegistryMessage", func() {
 				"private_instance_index": "0",
 				"route_service_url": "https://hello.com",
 				"endpoint_updated_at_ns": 1000,
-				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"}
+				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"},
+				"availability_zone": "some-zone"
 			}`
 		})
 
@@ -76,7 +78,8 @@ var _ = Describe("RegistryMessage", func() {
 				"server_cert_domain_san": "instance-guid",
 				"route_service_url": "https://hello.com",
 				"endpoint_updated_at_ns": 1000,
-				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"}
+				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"},
+				"availability_zone": "some-zone"
 			}`
 			})
 
@@ -104,7 +107,8 @@ var _ = Describe("RegistryMessage", func() {
 				"server_cert_domain_san": "instance-guid",
 				"route_service_url": "https://hello.com",
 				"endpoint_updated_at_ns": 1000,
-				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"}
+				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"},
+				"availability_zone": "some-zone"
 			}`
 			})
 
@@ -124,12 +128,13 @@ var _ = Describe("RegistryMessage", func() {
 
 		BeforeEach(func() {
 			endpoint = routingtable.Endpoint{
-				InstanceGUID:  "instance-guid",
-				Index:         0,
-				Host:          "1.1.1.1",
-				Port:          61001,
-				ContainerPort: 11,
-				Since:         2000,
+				InstanceGUID:     "instance-guid",
+				Index:            0,
+				Host:             "1.1.1.1",
+				Port:             61001,
+				ContainerPort:    11,
+				Since:            2000,
+				AvailabilityZone: "some-zone",
 			}
 
 			route = routingtable.Route{
@@ -195,16 +200,18 @@ var _ = Describe("RegistryMessage", func() {
 				RouteServiceUrl:      "https://hello.com",
 				EndpointUpdatedAtNs:  2000,
 				Tags:                 map[string]string{"component": "route-emitter", "foo": "bar", "doo": "0"},
+				AvailabilityZone:     "some-zone",
 			}
 
 			endpoint = routingtable.Endpoint{
-				InstanceGUID:  "instance-guid",
-				Index:         0,
-				Host:          "1.1.1.1",
-				ContainerIP:   "1.2.3.4",
-				Port:          61001,
-				ContainerPort: 11,
-				Since:         2000,
+				InstanceGUID:     "instance-guid",
+				Index:            0,
+				Host:             "1.1.1.1",
+				ContainerIP:      "1.2.3.4",
+				Port:             61001,
+				ContainerPort:    11,
+				Since:            2000,
+				AvailabilityZone: "some-zone",
 			}
 			route = routingtable.Route{
 				Hostname:        "host-1.example.com",
@@ -259,16 +266,18 @@ var _ = Describe("RegistryMessage", func() {
 				Tags:                 map[string]string{"component": "route-emitter"},
 				EndpointUpdatedAtNs:  2000,
 				PrivateInstanceIndex: "0",
+				AvailabilityZone:     "some-zone",
 			}
 
 			endpoint = routingtable.Endpoint{
-				InstanceGUID:  "instance-guid",
-				Index:         0,
-				Host:          "1.1.1.1",
-				ContainerIP:   "1.2.3.4",
-				Port:          61001,
-				ContainerPort: 11,
-				Since:         2000,
+				InstanceGUID:     "instance-guid",
+				Index:            0,
+				Host:             "1.1.1.1",
+				ContainerIP:      "1.2.3.4",
+				Port:             61001,
+				ContainerPort:    11,
+				Since:            2000,
+				AvailabilityZone: "some-zone",
 			}
 
 			route = routingtable.InternalRoute{


### PR DESCRIPTION
### What is this change about?

Route Emitter sends availability zone that it received in BBS events in the Registry Message to the Gorouter.

### What problem it is trying to solve?

This will Gorouter to make decisions based on balancing algorithm.

### How should this change be described in diego-release release notes?

[Feature] Diego advertises the availability zone of an LRP to enable clever intra-AZ routing

### Please provide any contextual information.

[tracker story](https://www.pivotaltracker.com/story/show/186117279)
[issue](https://github.com/cloudfoundry/routing-release/issues/356)

Thank you!
