### PR TITLE
Update to use newer signature for NewTcpRouteMapping function

### DIFF
--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -473,8 +473,8 @@ var _ = Describe("Route Emitter", func() {
 			cfgs = append(cfgs, func(cfg *config.RouteEmitterConfig) {
 				cfg.EnableTCPEmitter = true
 			})
-			expectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 5222, "some-ip", 62003, 120)
-			notExpectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 1883, "some-ip-1", 62003, 120)
+			expectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 5222, "some-ip", 62003, 0, "", nil, 120, apimodels.ModificationTag{})
+			notExpectedTcpRouteMapping = apimodels.NewTcpRouteMapping("", 1883, "some-ip-1", 62003, 0, "", nil, 120, apimodels.ModificationTag{})
 			expectedTcpRouteMapping.RouterGroupGuid = routerGUID
 			notExpectedTcpRouteMapping.RouterGroupGuid = routerGUID
 			cellID = ""
@@ -711,7 +711,7 @@ var _ = Describe("Route Emitter", func() {
 							By("unblocking the sync loop")
 							close(blkChannel)
 
-							expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, 120)
+							expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, 0, "", nil, 120, apimodels.ModificationTag{})
 
 							Eventually(routingAPIClient.TcpRouteMappings, 5*time.Second).Should(
 								ContainElement(matchTCPRouteMapping(expectedTcpRouteMapping)),
@@ -956,7 +956,7 @@ var _ = Describe("Route Emitter", func() {
 						By("unblocking the sync loop")
 						close(blkChannel)
 
-						expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, 120)
+						expectedTcpRouteMapping = apimodels.NewTcpRouteMapping(routerGUID, 5222, "some-ip", 5222, 0, "", nil, 120, apimodels.ModificationTag{})
 
 						Eventually(routingAPIClient.TcpRouteMappings, 5*time.Second).Should(
 							ContainElement(matchTCPRouteMapping(expectedTcpRouteMapping)),

--- a/emitter/routing_api_emitter_test.go
+++ b/emitter/routing_api_emitter_test.go
@@ -38,11 +38,11 @@ var _ = Describe("RoutingAPIEmitter", func() {
 		routingAPIEmitter = emitter.NewRoutingAPIEmitter(logger, routingApiClient, uaaTokenFetcher, ttl)
 
 		routingEvents = routingtable.TCPRouteMappings{
-			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0)},
+			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{})},
 		}
 
 		expectedRoutingEvents = routingtable.TCPRouteMappings{
-			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, int(ttl))},
+			Registrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{})},
 		}
 
 		token := &oauth2.Token{
@@ -100,10 +100,10 @@ var _ = Describe("RoutingAPIEmitter", func() {
 			Context("and there are unregistration events", func() {
 				BeforeEach(func() {
 					routingEvents = routingtable.TCPRouteMappings{
-						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0)},
+						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 0, apimodels.ModificationTag{})},
 					}
 					expectedRoutingEvents = routingtable.TCPRouteMappings{
-						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 60)},
+						Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, 60, apimodels.ModificationTag{})},
 					}
 				})
 
@@ -166,7 +166,7 @@ var _ = Describe("RoutingAPIEmitter", func() {
 			BeforeEach(func() {
 				routingApiClient.DeleteTcpRouteMappingsReturns(errors.New("unauthorized"))
 				routingEvents = routingtable.TCPRouteMappings{
-					Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, int(ttl))},
+					Unregistrations: []apimodels.TcpRouteMapping{apimodels.NewTcpRouteMapping("123", 61000, "some-ip-1", 62003, 0, "", nil, int(ttl), apimodels.ModificationTag{})},
 				}
 			})
 

--- a/routingtable/endpoint.go
+++ b/routingtable/endpoint.go
@@ -95,22 +95,36 @@ func (info ExternalEndpointInfo) Hash() interface{} {
 	return info
 }
 
+func pointerToInt(i int) *int { return &i }
+
 func (info ExternalEndpointInfo) MessageFor(e Endpoint, directInstanceRoute, _ bool) (*RegistryMessage, *tcpmodels.TcpRouteMapping, *RegistryMessage) {
-	mapping := tcpmodels.NewTcpRouteMapping(
-		info.RouterGroupGUID,
-		uint16(info.Port),
-		e.Host,
-		uint16(e.Port),
-		0,
-	)
+	mapping := tcpmodels.TcpRouteMapping{
+		TcpMappingEntity: tcpmodels.TcpMappingEntity{
+			RouterGroupGuid: info.RouterGroupGUID,
+			ExternalPort:    uint16(info.Port),
+			HostIP:          e.Host,
+			HostPort:        uint16(e.Port),
+			HostTLSPort:     nil,
+			InstanceId:      "",
+			SniHostname:     nil,
+			TTL:             pointerToInt(0),
+			ModificationTag: tcpmodels.ModificationTag{},
+		},
+	}
 	if e.IsDirectInstanceRoute(directInstanceRoute) {
-		mapping = tcpmodels.NewTcpRouteMapping(
-			info.RouterGroupGUID,
-			uint16(info.Port),
-			e.ContainerIP,
-			uint16(e.ContainerPort),
-			0,
-		)
+		mapping = tcpmodels.TcpRouteMapping{
+			TcpMappingEntity: tcpmodels.TcpMappingEntity{
+				RouterGroupGuid: info.RouterGroupGUID,
+				ExternalPort:    uint16(info.Port),
+				HostIP:          e.ContainerIP,
+				HostPort:        uint16(e.ContainerPort),
+				HostTLSPort:     nil,
+				InstanceId:      "",
+				SniHostname:     nil,
+				TTL:             pointerToInt(0),
+				ModificationTag: tcpmodels.ModificationTag{},
+			},
+		}
 	}
 	return nil, &mapping, nil
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Updates route-emitter code to handle the new routing-api models + generator function for TCP routes.

Backward Compatibility
---------------
Breaking Change? **Yes/No**

No