### PR TITLE
Update go-loggregator to v9

### DIFF
--- a/cmd/route-emitter/main.go
+++ b/cmd/route-emitter/main.go
@@ -15,7 +15,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/debugserver"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
-	"code.cloudfoundry.org/go-loggregator/v8/runtimeemitter"
+	"code.cloudfoundry.org/go-loggregator/v9/runtimeemitter"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerflags"
 	"code.cloudfoundry.org/locket"

--- a/cmd/route-emitter/main_suite_test.go
+++ b/cmd/route-emitter/main_suite_test.go
@@ -18,7 +18,7 @@ import (
 	"code.cloudfoundry.org/bbs/test_helpers/sqlrunner"
 	"code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/durationjson"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 	"code.cloudfoundry.org/inigo/helpers/certauthority"
 	"code.cloudfoundry.org/inigo/helpers/portauthority"
 	"code.cloudfoundry.org/lager/v3/lagerflags"

--- a/routehandlers/handler_test.go
+++ b/routehandlers/handler_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"code.cloudfoundry.org/lager/v3"
 	ufakes "code.cloudfoundry.org/route-emitter/unregistration/fakes"
 

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -3,7 +3,7 @@ package routehandlers_test
 import (
 	"code.cloudfoundry.org/bbs/models"
 	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	emitterfakes "code.cloudfoundry.org/route-emitter/emitter/fakes"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Update go-loggregator/v8 to go-loggregator/v9


Backward Compatibility
---------------
Breaking Change? **No**