### PR TITLE
feat: Implement per-route options forwarding in route-emitter

### DIFF
--- a/routingtable/endpoint.go
+++ b/routingtable/endpoint.go
@@ -1,6 +1,7 @@
 package routingtable
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"code.cloudfoundry.org/bbs/models"
@@ -141,6 +142,7 @@ type Route struct {
 	LogGUID          string
 	Protocol         string
 	MetricTags       map[string]*models.MetricTagValue
+	Options          json.RawMessage
 }
 
 type routeHash struct {

--- a/routingtable/registry_message.go
+++ b/routingtable/registry_message.go
@@ -1,6 +1,7 @@
 package routingtable
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -22,6 +23,7 @@ type RegistryMessage struct {
 	EndpointUpdatedAtNs  int64             `json:"endpoint_updated_at_ns,omitempty" hash:"ignore"`
 	Tags                 map[string]string `json:"tags,omitempty" hash:"ignore"`
 	AvailabilityZone     string            `json:"availability_zone,omitempty" hash:"ignore"`
+	Options              json.RawMessage   `json:"options,omitempty" hash:"ignore"`
 }
 
 func RegistryMessageFor(endpoint Endpoint, route Route, emitEndpointUpdatedAt bool) RegistryMessage {

--- a/routingtable/registry_message.go
+++ b/routingtable/registry_message.go
@@ -52,6 +52,7 @@ func RegistryMessageFor(endpoint Endpoint, route Route, emitEndpointUpdatedAt bo
 		PrivateInstanceIndex: index,
 		ServerCertDomainSAN:  endpoint.InstanceGUID,
 		RouteServiceUrl:      route.RouteServiceUrl,
+		Options:              route.Options,
 	}
 }
 

--- a/routingtable/registry_message_test.go
+++ b/routingtable/registry_message_test.go
@@ -120,6 +120,34 @@ var _ = Describe("RegistryMessage", func() {
 				Expect(message).To(Equal(expectedMessage))
 			})
 		})
+
+		Context("when a route option is provided", func() {
+			BeforeEach(func() {
+				expectedMessage.Options = json.RawMessage(`{"lb_algo":"least-connection"}`)
+				expectedJSON = `{
+				"host": "1.1.1.1",
+				"port": 61001,
+				"uris": ["host-1.example.com"],
+				"app" : "app-guid",
+				"private_instance_id": "instance-guid",
+				"server_cert_domain_san": "instance-guid",
+				"private_instance_index": "0",
+				"route_service_url": "https://hello.com",
+				"endpoint_updated_at_ns": 1000,
+				"tags": {"component":"route-emitter", "doo": "0", "foo": "bar", "goo": "instance-guid"},
+				"availability_zone": "some-zone",
+				"options": {"lb_algo":"least-connection"}
+			}`
+			})
+
+			It("correctly marshals the route option", func() {
+				message := routingtable.RegistryMessage{}
+
+				err := json.Unmarshal([]byte(expectedJSON), &message)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(message).To(Equal(expectedMessage))
+			})
+		})
 	})
 
 	Describe("RegistryMessageFor", func() {
@@ -178,6 +206,18 @@ var _ = Describe("RegistryMessage", func() {
 			})
 
 			It("creates a valid message when instance index is greater than 0", func() {
+				message := routingtable.RegistryMessageFor(endpoint, route, true)
+				Expect(message).To(Equal(expectedMessage))
+			})
+		})
+
+		Context("when route options are provided", func() {
+			BeforeEach(func() {
+				route.Options = json.RawMessage(`{"lb_algo":"least-connection"}`)
+				expectedMessage.Options = json.RawMessage(`{"lb_algo":"least-connection"}`)
+			})
+
+			It("creates a valid message when route options are provided", func() {
 				message := routingtable.RegistryMessageFor(endpoint, route, true)
 				Expect(message).To(Equal(expectedMessage))
 			})

--- a/routingtable/routingtable.go
+++ b/routingtable/routingtable.go
@@ -444,6 +444,7 @@ func httpRoutesFrom(lrp *models.DesiredLRP) map[RoutingKey][]routeMapping {
 				IsolationSegment: route.IsolationSegment,
 				MetricTags:       lrp.MetricTags,
 				Protocol:         route.Protocol,
+				Options:          route.Options,
 			}
 			routes = append(routes, route)
 		}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* Part of [RFC 0027 - Generic Per-Route Features](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md) ([Tracking issue](https://github.com/cloudfoundry/community/issues/909))
* Enables `route-emitter` to forward the route-specific`Options` field to Gorouter
* Corresponding PR: 

Backward Compatibility
---------------
Breaking Change? **No**
