### PR TITLE
Pass uint16's to routing-api for port numbers

### DIFF
--- a/cmd/route-emitter/runners/routingapi.go
+++ b/cmd/route-emitter/runners/routingapi.go
@@ -39,7 +39,7 @@ func NewRoutingAPIRunner(binPath string, adminPort int, sqlConfig SQLConfig, fs 
 	cfg := Config{
 		DevMode: true,
 		Config: apiconfig.Config{
-			AdminPort: adminPort,
+			AdminPort: uint16(adminPort),
 			// required fields
 			MetricsReportingIntervalString:  "500ms",
 			StatsdClientFlushIntervalString: "10ms",
@@ -55,7 +55,7 @@ func NewRoutingAPIRunner(binPath string, adminPort int, sqlConfig SQLConfig, fs 
 			// end of required fields
 			SqlDB: apiconfig.SqlDB{
 				Host:     "localhost",
-				Port:     sqlConfig.Port,
+				Port:     uint16(sqlConfig.Port),
 				Schema:   sqlConfig.DBName,
 				Type:     sqlConfig.DriverName,
 				Username: sqlConfig.Username,


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Allows diego-release to bump dependencies again. Will revisit later with proper uint16 handling for ports across diego


Backward Compatibility
---------------
Breaking Change? no
