### PR TITLE
Use golang/protobuf instead of gogo/protobuf

### DIFF
--- a/cmd/route-emitter/main.go
+++ b/cmd/route-emitter/main.go
@@ -162,7 +162,7 @@ func main() {
 		lockIdentifier := &locketmodels.Resource{
 			Key:      routeEmitterLockKey,
 			Owner:    cfg.UUID,
-			TypeCode: locketmodels.TypeCode_LOCK,
+			TypeCode: locketmodels.LOCK,
 			Type:     locketmodels.LockType,
 		}
 

--- a/cmd/route-emitter/main.go
+++ b/cmd/route-emitter/main.go
@@ -162,7 +162,7 @@ func main() {
 		lockIdentifier := &locketmodels.Resource{
 			Key:      routeEmitterLockKey,
 			Owner:    cfg.UUID,
-			TypeCode: locketmodels.LOCK,
+			TypeCode: locketmodels.TypeCode_LOCK,
 			Type:     locketmodels.LockType,
 		}
 

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -1117,7 +1117,7 @@ var _ = Describe("Route Emitter", func() {
 					Key:      "route_emitter",
 					Owner:    "Your worst enemy.",
 					Value:    "Something",
-					TypeCode: locketmodels.LOCK,
+					TypeCode: locketmodels.TypeCode_LOCK,
 				}
 
 				clock := clock.NewClock()
@@ -2120,8 +2120,8 @@ var _ = Describe("Route Emitter", func() {
 					updateRequest := &models.DesiredLRPUpdate{
 						Routes: newRoutes(hostnames, containerPort, ""),
 					}
-					updateRequest.SetInstances(desiredLRP.Instances)
-					updateRequest.SetAnnotation(desiredLRP.Annotation)
+					updateRequest.SetInstances(&desiredLRP.Instances)
+					updateRequest.SetAnnotation(&desiredLRP.Annotation)
 
 					err := bbsClient.UpdateDesiredLRP(logger, "", processGuid, updateRequest)
 					Expect(err).NotTo(HaveOccurred())
@@ -2195,8 +2195,8 @@ var _ = Describe("Route Emitter", func() {
 					updateRequest := &models.DesiredLRPUpdate{
 						Routes: newRoutes([]string{"route-2"}, containerPort, ""),
 					}
-					updateRequest.SetInstances(desiredLRP.Instances)
-					updateRequest.SetAnnotation(desiredLRP.Annotation)
+					updateRequest.SetInstances(&desiredLRP.Instances)
+					updateRequest.SetAnnotation(&desiredLRP.Annotation)
 					err := bbsClient.UpdateDesiredLRP(logger, "", processGuid, updateRequest)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -2256,8 +2256,8 @@ var _ = Describe("Route Emitter", func() {
 					updateRequest := &models.DesiredLRPUpdate{
 						Routes: newRoutes([]string{"route-2"}, containerPort, "https://awesome.com"),
 					}
-					updateRequest.SetInstances(desiredLRP.Instances)
-					updateRequest.SetAnnotation(desiredLRP.Annotation)
+					updateRequest.SetInstances(&desiredLRP.Instances)
+					updateRequest.SetAnnotation(&desiredLRP.Annotation)
 					err := bbsClient.UpdateDesiredLRP(logger, "", processGuid, updateRequest)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -297,7 +297,7 @@ var _ = Describe("Route Emitter", func() {
 		})
 
 		sqlConfig := runners.SQLConfig{
-			Port:       sqlRunner.Port(),
+			Port:       uint16(sqlRunner.Port()),
 			DBName:     sqlRunner.DBName(),
 			DriverName: sqlRunner.DriverName(),
 			Username:   sqlRunner.Username(),
@@ -330,7 +330,7 @@ var _ = Describe("Route Emitter", func() {
 		})
 		routingAPILocketProcess = ginkgomon.Invoke(routingAPILocketRunner)
 		routingAPIPort := port + 2
-		routingAPIRunner, err = runners.NewRoutingAPIRunner(routingAPIPath, int(port+1), sqlConfig, func(cfg *runners.Config) {
+		routingAPIRunner, err = runners.NewRoutingAPIRunner(routingAPIPath, uint16(port+1), sqlConfig, func(cfg *runners.Config) {
 			cfg.API = routinapiconfig.APIConfig{
 				ListenPort:         port,
 				HTTPEnabled:        false,

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -872,8 +872,10 @@ var _ = Describe("Route Emitter", func() {
 							Eventually(routingAPIClient.TcpRouteMappings, 5*time.Second).Should(
 								ContainElement(matchTCPRouteMapping(expectedTcpRouteMapping)),
 							)
+							instances := int32(0)
 							update := &models.DesiredLRPUpdate{
-								Routes: &models.Routes{},
+								Instances: &instances,
+								Routes:    &models.Routes{},
 							}
 							err := bbsClient.UpdateDesiredLRP(logger, "", desiredLRP.ProcessGuid, update)
 							Expect(err).NotTo(HaveOccurred())

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -1119,7 +1119,7 @@ var _ = Describe("Route Emitter", func() {
 					Key:      "route_emitter",
 					Owner:    "Your worst enemy.",
 					Value:    "Something",
-					TypeCode: locketmodels.TypeCode_LOCK,
+					TypeCode: locketmodels.LOCK,
 				}
 
 				clock := clock.NewClock()

--- a/cmd/route-emitter/runners/routingapi.go
+++ b/cmd/route-emitter/runners/routingapi.go
@@ -28,14 +28,14 @@ type RoutingAPIRunner struct {
 }
 
 type SQLConfig struct {
-	Port       int
+	Port       uint16
 	DBName     string
 	DriverName string
 	Username   string
 	Password   string
 }
 
-func NewRoutingAPIRunner(binPath string, adminPort int, sqlConfig SQLConfig, fs ...func(*Config)) (*RoutingAPIRunner, error) {
+func NewRoutingAPIRunner(binPath string, adminPort uint16, sqlConfig SQLConfig, fs ...func(*Config)) (*RoutingAPIRunner, error) {
 	cfg := Config{
 		DevMode: true,
 		Config: apiconfig.Config{

--- a/routehandlers/handler.go
+++ b/routehandlers/handler.go
@@ -78,8 +78,8 @@ func (handler *Handler) HandleEvent(logger lager.Logger, event models.Event) {
 		handler.handleActualCreate(logger, event.ActualLrp)
 	case *models.ActualLRPInstanceChangedEvent:
 		logger = trace.LoggerWithTraceInfo(logger, event.TraceId)
-		before := event.Before.ToActualLRP(event.ActualLRPKey, event.ActualLRPInstanceKey)
-		after := event.After.ToActualLRP(event.ActualLRPKey, event.ActualLRPInstanceKey)
+		before := event.Before.ToActualLRP(event.ActualLrpKey, event.ActualLrpInstanceKey)
+		after := event.After.ToActualLRP(event.ActualLrpKey, event.ActualLrpInstanceKey)
 		logger.Debug("received-actual-lrp-changed-event", lager.Data{"before": before, "after": after})
 		if before == nil || after == nil {
 			logger.Error("nil-actual-lrp", nil, lager.Data{"event-type": event.EventType()})
@@ -268,9 +268,9 @@ func (handler *Handler) handleActualUpdate(logger lager.Logger, before, after *m
 	)
 	switch {
 	case after.State == models.ActualLRPStateRunning:
-		if !after.RoutableExists() || after.GetRoutable() {
+		if !after.RoutableExists() || *after.GetRoutable() {
 			routeMappings, messagesToEmit = handler.routingTable.AddEndpoint(logger, after)
-		} else if before.GetRoutable() {
+		} else if *before.GetRoutable() {
 			routeMappings, messagesToEmit = handler.routingTable.RemoveEndpoint(logger, after)
 		}
 

--- a/routehandlers/routing_api_handler_test.go
+++ b/routehandlers/routing_api_handler_test.go
@@ -174,9 +174,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when state is Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -208,9 +208,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when state is not in Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -242,9 +242,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when after state is Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -253,9 +253,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 					}
 
 					afterLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -267,7 +267,8 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				Context("when Routable is true", func() {
 					BeforeEach(func() {
-						afterLRP.SetRoutable(true)
+						routableTrue := true
+						afterLRP.SetRoutable(&routableTrue)
 					})
 
 					It("invokes AddEndpoint on RoutingTable", func() {
@@ -293,9 +294,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when after state is not Running and before state is Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -305,9 +306,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 					}
 
 					afterLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -338,9 +339,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when both after and before state is not Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", ""),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", ""),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -349,9 +350,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 					}
 
 					afterLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -378,9 +379,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when state is Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -412,9 +413,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 			Context("when state is not in Running", func() {
 				BeforeEach(func() {
 					actualLRP = &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"",
 							"",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -438,9 +439,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 		var actualLRP *models.ActualLRP
 		BeforeEach(func() {
 			actualLRP = &models.ActualLRP{
-				ActualLRPKey:         models.NewActualLRPKey("process-guid-1", 0, "domain"),
-				ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-				ActualLRPNetInfo: models.NewActualLRPNetInfo(
+				ActualLrpKey:         models.NewActualLRPKey("process-guid-1", 0, "domain"),
+				ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+				ActualLrpNetInfo: models.NewActualLRPNetInfo(
 					"some-ip",
 					"container-ip",
 					models.ActualLRPNetInfo_PreferredAddressHost,
@@ -535,9 +536,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 
 				actualLRPs = []*models.ActualLRP{
 					&models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid-1", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid-1", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip",
 							"container-ip",
 							models.ActualLRPNetInfo_PreferredAddressHost,
@@ -625,9 +626,9 @@ var _ = Describe("RoutingAPIHandler", func() {
 					}, "some-trace-id")
 
 					actualLRPEvent := models.NewActualLRPInstanceCreatedEvent(&models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid-2", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid-1", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid-2", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid-1", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"some-ip-2",
 							"container-ip-2",
 							models.ActualLRPNetInfo_PreferredAddressHost,

--- a/routingtable/endpoint.go
+++ b/routingtable/endpoint.go
@@ -226,13 +226,13 @@ type InternalRoutableEndpoints struct {
 
 func NewEndpointsFromActual(actualLRP *models.ActualLRP) []Endpoint {
 	endpoints := []Endpoint{}
-	for _, portMapping := range actualLRP.Ports {
+	for _, portMapping := range actualLRP.ActualLrpNetInfo.Ports {
 		if portMapping != nil {
 			endpoint := Endpoint{
-				InstanceGUID:          actualLRP.InstanceGuid,
-				Index:                 actualLRP.Index,
-				Host:                  actualLRP.Address,
-				ContainerIP:           actualLRP.InstanceAddress,
+				InstanceGUID:          actualLRP.ActualLrpInstanceKey.InstanceGuid,
+				Index:                 actualLRP.ActualLrpKey.Index,
+				Host:                  actualLRP.ActualLrpNetInfo.Address,
+				ContainerIP:           actualLRP.ActualLrpNetInfo.InstanceAddress,
 				Port:                  portMapping.HostPort,
 				ContainerPort:         portMapping.ContainerPort,
 				Presence:              actualLRP.Presence,
@@ -240,7 +240,7 @@ func NewEndpointsFromActual(actualLRP *models.ActualLRP) []Endpoint {
 				TlsProxyPort:          portMapping.HostTlsProxyPort,
 				ContainerTlsProxyPort: portMapping.ContainerTlsProxyPort,
 				Since:                 actualLRP.Since,
-				PreferredAddress:      actualLRP.PreferredAddress,
+				PreferredAddress:      actualLRP.ActualLrpNetInfo.PreferredAddress,
 				AvailabilityZone:      actualLRP.AvailabilityZone,
 			}
 			endpoints = append(endpoints, endpoint)
@@ -252,11 +252,11 @@ func NewEndpointsFromActual(actualLRP *models.ActualLRP) []Endpoint {
 
 func NewRoutingKeysFromActual(actualLRP *models.ActualLRP) RoutingKeys {
 	keys := RoutingKeys{}
-	for _, portMapping := range actualLRP.Ports {
-		keys = append(keys, NewRoutingKey(actualLRP.ProcessGuid, portMapping.ContainerPort))
+	for _, portMapping := range actualLRP.ActualLrpNetInfo.Ports {
+		keys = append(keys, NewRoutingKey(actualLRP.ActualLrpKey.ProcessGuid, portMapping.ContainerPort))
 
 		if portMapping.HostTlsProxyPort != 0 && portMapping.ContainerTlsProxyPort != 0 {
-			keys = append(keys, NewRoutingKey(actualLRP.ProcessGuid, portMapping.ContainerTlsProxyPort))
+			keys = append(keys, NewRoutingKey(actualLRP.ActualLrpKey.ProcessGuid, portMapping.ContainerTlsProxyPort))
 		}
 	}
 

--- a/routingtable/endpoint_utils_test.go
+++ b/routingtable/endpoint_utils_test.go
@@ -55,9 +55,9 @@ var _ = Describe("LRP Utils", func() {
 			It("builds a map of container port to endpoint", func() {
 				tag := models.ModificationTag{Epoch: "abc", Index: 0}
 				actualInfo := &models.ActualLRP{
-					ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-					ActualLRPNetInfo: models.NewActualLRPNetInfo(
+					ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+					ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+					ActualLrpNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
 						models.ActualLRPNetInfo_PreferredAddressHost,
@@ -82,9 +82,9 @@ var _ = Describe("LRP Utils", func() {
 				It("builds a map of tls proxy ports to endpoints", func() {
 					tag := models.ModificationTag{Epoch: "abc", Index: 0}
 					actualInfo := &models.ActualLRP{
-						ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-						ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-						ActualLRPNetInfo: models.NewActualLRPNetInfo(
+						ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+						ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+						ActualLrpNetInfo: models.NewActualLRPNetInfo(
 							"1.1.1.1",
 							"2.2.2.2",
 							models.ActualLRPNetInfo_PreferredAddressInstance,
@@ -112,9 +112,9 @@ var _ = Describe("LRP Utils", func() {
 				tag := models.ModificationTag{Epoch: "abc", Index: 0}
 
 				actualInfo := &models.ActualLRP{
-					ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-					ActualLRPNetInfo: models.NewActualLRPNetInfo(
+					ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+					ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+					ActualLrpNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
 						models.ActualLRPNetInfo_PreferredAddressHost,
@@ -140,9 +140,9 @@ var _ = Describe("LRP Utils", func() {
 	Describe("NewRoutingKeysFromActual", func() {
 		It("creates a list of keys for an actual LRP", func() {
 			keys := routingtable.NewRoutingKeysFromActual(&models.ActualLRP{
-				ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-				ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-				ActualLRPNetInfo: models.NewActualLRPNetInfo(
+				ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+				ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+				ActualLrpNetInfo: models.NewActualLRPNetInfo(
 					"1.1.1.1",
 					"2.2.2.2",
 					models.ActualLRPNetInfo_PreferredAddressHost,
@@ -160,9 +160,9 @@ var _ = Describe("LRP Utils", func() {
 		Context("when the actual lrp has tls proxy ports", func() {
 			It("creates a list of keys for an actual LRP", func() {
 				keys := routingtable.NewRoutingKeysFromActual(&models.ActualLRP{
-					ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-					ActualLRPNetInfo: models.NewActualLRPNetInfo(
+					ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+					ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+					ActualLrpNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
 						models.ActualLRPNetInfo_PreferredAddressHost,
@@ -183,9 +183,9 @@ var _ = Describe("LRP Utils", func() {
 		Context("when the actual lrp has no port mappings", func() {
 			It("returns no keys", func() {
 				keys := routingtable.NewRoutingKeysFromActual(&models.ActualLRP{
-					ActualLRPKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
-					ActualLRPInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
-					ActualLRPNetInfo: models.NewActualLRPNetInfo(
+					ActualLrpKey:         models.NewActualLRPKey("process-guid", 0, "domain"),
+					ActualLrpInstanceKey: models.NewActualLRPInstanceKey("instance-guid", "cell-id"),
+					ActualLrpNetInfo: models.NewActualLRPNetInfo(
 						"1.1.1.1",
 						"2.2.2.2",
 						models.ActualLRPNetInfo_PreferredAddressHost,

--- a/routingtable/lrp_utils.go
+++ b/routingtable/lrp_utils.go
@@ -28,13 +28,13 @@ func DesiredLRPData(lrp *models.DesiredLRP) lager.Data {
 
 func ActualLRPData(actualLRP *models.ActualLRP) lager.Data {
 	return lager.Data{
-		"process-guid":  actualLRP.ProcessGuid,
-		"index":         actualLRP.Index,
-		"domain":        actualLRP.Domain,
-		"instance-guid": actualLRP.InstanceGuid,
-		"cell-id":       actualLRP.CellId,
-		"address":       actualLRP.Address,
-		"ports":         actualLRP.Ports,
+		"process-guid":  actualLRP.ActualLrpKey.ProcessGuid,
+		"index":         actualLRP.ActualLrpKey.Index,
+		"domain":        actualLRP.ActualLrpKey.Domain,
+		"instance-guid": actualLRP.ActualLrpInstanceKey.InstanceGuid,
+		"cell-id":       actualLRP.ActualLrpInstanceKey.CellId,
+		"address":       actualLRP.ActualLrpNetInfo.Address,
+		"ports":         actualLRP.ActualLrpNetInfo.Ports,
 		"evacuating":    actualLRP.Presence == models.ActualLRP_Evacuating,
 		"state":         actualLRP.State,
 	}

--- a/routingtable/nats_routing_table_test.go
+++ b/routingtable/nats_routing_table_test.go
@@ -195,7 +195,7 @@ var _ = Describe("RoutingTable", func() {
 		BeforeEach(func() {
 			table = routingtable.NewRoutingTable(true, false, fakeMetronClient)
 			desiredLRP := createDesiredLRP(key.ProcessGUID, int32(3), key.ContainerPort, logGuid, "", *currentTag, models.DesiredLRPRunInfo{}, hostname1)
-			desiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex}}
+			desiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex}}
 			table.SetRoutes(logger, nil, desiredLRP)
 		})
 

--- a/routingtable/registry_message.go
+++ b/routingtable/registry_message.go
@@ -118,9 +118,9 @@ func populateMetricTags(input map[string]*models.MetricTagValue, endpoint Endpoi
 		var value string
 		if v.Dynamic > 0 {
 			switch v.Dynamic {
-			case models.MetricTagDynamicValueIndex:
+			case models.MetricTagValue_MetricTagDynamicValueIndex:
 				value = strconv.FormatInt(int64(endpoint.Index), 10)
-			case models.MetricTagDynamicValueInstanceGuid:
+			case models.MetricTagValue_MetricTagDynamicValueInstanceGuid:
 				value = endpoint.InstanceGUID
 			}
 		} else {

--- a/routingtable/registry_message_test.go
+++ b/routingtable/registry_message_test.go
@@ -171,8 +171,8 @@ var _ = Describe("RegistryMessage", func() {
 				RouteServiceUrl: "https://hello.com",
 				MetricTags: map[string]*models.MetricTagValue{
 					"foo": &models.MetricTagValue{Static: "bar"},
-					"doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex},
-					"goo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueInstanceGuid},
+					"doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex},
+					"goo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueInstanceGuid},
 				},
 			}
 
@@ -259,7 +259,7 @@ var _ = Describe("RegistryMessage", func() {
 				RouteServiceUrl: "https://hello.com",
 				MetricTags: map[string]*models.MetricTagValue{
 					"foo": &models.MetricTagValue{Static: "bar"},
-					"doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex},
+					"doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex},
 				},
 			}
 

--- a/routingtable/routingtable.go
+++ b/routingtable/routingtable.go
@@ -115,10 +115,10 @@ func NewRoutingTable(directInstanceRoute bool, tcpTLSEnabled bool, metronClient 
 func internalEndpointsFromActualLRP(actualLRP *models.ActualLRP) []Endpoint {
 	return []Endpoint{
 		{
-			InstanceGUID:    actualLRP.InstanceGuid,
-			Index:           actualLRP.Index,
-			Host:            actualLRP.Address,
-			ContainerIP:     actualLRP.InstanceAddress,
+			InstanceGUID:    actualLRP.ActualLrpInstanceKey.InstanceGuid,
+			Index:           actualLRP.ActualLrpKey.Index,
+			Host:            actualLRP.ActualLrpNetInfo.Address,
+			ContainerIP:     actualLRP.ActualLrpNetInfo.InstanceAddress,
 			Presence:        actualLRP.Presence,
 			Since:           actualLRP.Since,
 			ModificationTag: &actualLRP.ModificationTag,
@@ -257,7 +257,7 @@ func (table *internalRoutingTable) AddEndpoint(logger lager.Logger, actualLRP *m
 
 	for _, routingEndpoint := range endpoints {
 		key := RoutingKey{
-			ProcessGUID:   actualLRP.ProcessGuid,
+			ProcessGUID:   actualLRP.ActualLrpKey.ProcessGuid,
 			ContainerPort: routingEndpoint.ContainerPort,
 		}
 		currentEntry := table.entries[key]
@@ -311,7 +311,7 @@ func (table *internalRoutingTable) RemoveEndpoint(logger lager.Logger, actualLRP
 	var mappings TCPRouteMappings
 	for _, routingEndpoint := range endpoints {
 		key := RoutingKey{
-			ProcessGUID:   actualLRP.ProcessGuid,
+			ProcessGUID:   actualLRP.ActualLrpKey.ProcessGuid,
 			ContainerPort: routingEndpoint.ContainerPort,
 		}
 

--- a/routingtable/routingtable.go
+++ b/routingtable/routingtable.go
@@ -485,7 +485,7 @@ func internalRoutesFrom(lrp *models.DesiredLRP) map[RoutingKey][]routeMapping {
 		return nil
 	}
 
-	routes, _ := internalroutes.InternalRoutesFromRoutingInfo(*lrp.Routes)
+	routes, _ := internalroutes.InternalRoutesFromRoutingInfo(lrp.Routes)
 
 	routeEntries := make(map[RoutingKey][]routeMapping)
 	for _, route := range routes {

--- a/routingtable/routingtable_test.go
+++ b/routingtable/routingtable_test.go
@@ -121,9 +121,9 @@ func createActualLRP(
 	}
 
 	return &models.ActualLRP{
-		ActualLRPKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, domain),
-		ActualLRPInstanceKey: models.NewActualLRPInstanceKey(instance.InstanceGUID, "cell-id"),
-		ActualLRPNetInfo: models.NewActualLRPNetInfo(
+		ActualLrpKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, domain),
+		ActualLrpInstanceKey: models.NewActualLRPInstanceKey(instance.InstanceGUID, "cell-id"),
+		ActualLrpNetInfo: models.NewActualLRPNetInfo(
 			instance.Host,
 			instance.ContainerIP,
 			instance.PreferredAddress,
@@ -144,9 +144,9 @@ func createActualLRPWithPortMappings(
 ) *models.ActualLRP {
 
 	return &models.ActualLRP{
-		ActualLRPKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, domain),
-		ActualLRPInstanceKey: models.NewActualLRPInstanceKey(instance.InstanceGUID, "cell-id"),
-		ActualLRPNetInfo: models.NewActualLRPNetInfo(
+		ActualLrpKey:         models.NewActualLRPKey(key.ProcessGUID, instance.Index, domain),
+		ActualLrpInstanceKey: models.NewActualLRPInstanceKey(instance.InstanceGUID, "cell-id"),
+		ActualLrpNetInfo: models.NewActualLRPNetInfo(
 			instance.Host,
 			instance.ContainerIP,
 			models.ActualLRPNetInfo_PreferredAddressHost,
@@ -374,7 +374,7 @@ var _ = Describe("RoutingTable", func() {
 					}
 					Expect(messagesToEmit).To(Equal(expected))
 
-					afterDesiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex}}
+					afterDesiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex}}
 					afterDesiredLRP.ModificationTag = &models.ModificationTag{Epoch: "lmn", Index: 0}
 					table.SetRoutes(logger, beforeDesiredLRP, afterDesiredLRP)
 
@@ -960,7 +960,7 @@ var _ = Describe("RoutingTable", func() {
 			BeforeEach(func() {
 				routes := createRoutingInfo(key.ContainerPort, []string{hostname1}, []string{}, "", []uint32{}, "")
 				desiredLRP := createDesiredLRPWithRoutes(key.ProcessGUID, 1, routes, logGuid, *currentTag, runInfo)
-				desiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex}}
+				desiredLRP.MetricTags = map[string]*models.MetricTagValue{"foo": &models.MetricTagValue{Static: "bar"}, "doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex}}
 				table.SetRoutes(logger, nil, desiredLRP)
 			})
 
@@ -976,7 +976,7 @@ var _ = Describe("RoutingTable", func() {
 								LogGUID:  logGuid,
 								MetricTags: map[string]*models.MetricTagValue{
 									"foo": &models.MetricTagValue{Static: "bar"},
-									"doo": &models.MetricTagValue{Dynamic: models.MetricTagDynamicValueIndex},
+									"doo": &models.MetricTagValue{Dynamic: models.MetricTagValue_MetricTagDynamicValueIndex},
 								},
 							},
 							true,

--- a/routingtable/tcp_routing_table_test.go
+++ b/routingtable/tcp_routing_table_test.go
@@ -70,9 +70,9 @@ var _ = Describe("TCPRoutingTable", func() {
 		modificationTag *models.ModificationTag,
 	) *models.ActualLRP {
 		return &models.ActualLRP{
-			ActualLRPKey:         models.NewActualLRPKey(processGuid, 0, "domain"),
-			ActualLRPInstanceKey: models.NewActualLRPInstanceKey(instanceGuid, "cell-id-1"),
-			ActualLRPNetInfo: models.NewActualLRPNetInfo(
+			ActualLrpKey:         models.NewActualLRPKey(processGuid, 0, "domain"),
+			ActualLrpInstanceKey: models.NewActualLRPInstanceKey(instanceGuid, "cell-id-1"),
+			ActualLrpNetInfo: models.NewActualLRPNetInfo(
 				hostAddress,
 				instanceAddress,
 				models.ActualLRPNetInfo_PreferredAddressUnknown,
@@ -239,7 +239,7 @@ var _ = Describe("TCPRoutingTable", func() {
 						beforeLRP := getDesiredLRP("process-guid-1", logGuid, tcpRoutes, modificationTag)
 						tempRoutingTable.SetRoutes(logger, nil, beforeLRP)
 						actualLRP := getActualLRP("process-guid-1", "instance-guid-1", "some-ip-1", "container-ip-1", 62004, 5222, 61443, 5443, modificationTag)
-						actualLRP.PreferredAddress = models.ActualLRPNetInfo_PreferredAddressHost
+						actualLRP.ActualLrpNetInfo.PreferredAddress = models.ActualLRPNetInfo_PreferredAddressHost
 						tempRoutingTable.AddEndpoint(logger, actualLRP)
 						Expect(tempRoutingTable.TCPAssociationsCount()).Should(Equal(1))
 						Expect(routingTable.TCPAssociationsCount()).Should(Equal(0))
@@ -769,7 +769,7 @@ var _ = Describe("TCPRoutingTable", func() {
 								oldActualLRP := getActualLRP("process-guid-1", "instance-guid-1", "some-ip-1", "container-ip-1", 62004, 5222, 61443, 5443, modificationTag)
 								routingTable.RemoveEndpoint(logger, oldActualLRP)
 								newActualLRP := oldActualLRP
-								newActualLRP.ActualLRPNetInfo = models.NewActualLRPNetInfo(
+								newActualLRP.ActualLrpNetInfo = models.NewActualLRPNetInfo(
 									"some-ip-1",
 									"container-ip-1",
 									models.ActualLRPNetInfo_PreferredAddressHost,

--- a/watcher/watcher_integration_test.go
+++ b/watcher/watcher_integration_test.go
@@ -135,17 +135,17 @@ var _ = Describe("Watcher Integration", func() {
 			}
 
 			actualLRP1 = &models.ActualLRP{
-				ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
-				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+				ActualLrpKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
+				ActualLrpInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
+				ActualLrpNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 				State:                models.ActualLRPStateRunning,
 				ModificationTag:      *modTag,
 			}
 
 			removedActualLRP = &models.ActualLRP{
-				ActualLRPKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
-				ActualLRPInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
-				ActualLRPNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
+				ActualLrpKey:         models.NewActualLRPKey("pg-1", 0, "domain"),
+				ActualLrpInstanceKey: models.NewActualLRPInstanceKey(endpoint1.InstanceGUID, "cell-id"),
+				ActualLrpNetInfo:     models.NewActualLRPNetInfo(endpoint1.Host, "container-ip", models.ActualLRPNetInfo_PreferredAddressHost, models.NewPortMapping(endpoint1.Port, endpoint1.ContainerPort)),
 				State:                models.ActualLRPStateRunning,
 				ModificationTag:      *modTag,
 			}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[gogo/protobuf](https://github.com/gogo/protobuf) has been deprecated for years.  We should be using up-to-date protobufs provided by [google.golang.org/protobuf](https://github.com/protocolbuffers/protobuf-go).  In order to fit our use cases, a protobuf plugin (`protoc-gen-go-bbs`) has been created to catch any customizations we want to add.


Backward Compatibility
---------------
Breaking Change? **No**
