### PR TITLE
cleanup rep require tls property

### DIFF
--- a/cmd/route-emitter/main_suite_test.go
+++ b/cmd/route-emitter/main_suite_test.go
@@ -167,7 +167,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		MaxIdleDatabaseConnections:  200,
 		AuctioneerRequireTLS:        false,
 		RepClientSessionCacheSize:   0,
-		RepRequireTLS:               false,
 		LagerConfig: lagerflags.LagerConfig{
 			LogLevel:            string(lagerflags.DEBUG),
 			RedactSecrets:       false,


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup rep require tls property

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
