### PR TITLE
Remove old property: locks.locket.enabled - Diego release

### DIFF
--- a/cmd/route-emitter/config/config.go
+++ b/cmd/route-emitter/config/config.go
@@ -63,7 +63,6 @@ type RouteEmitterConfig struct {
 	UnregistrationInterval       durationjson.Duration `json:"unregistration_interval,omitempty"`
 	UnregistrationSendCount      int                   `json:"unregistration_send_count,omitempty"`
 	EnableInternalEmitter        bool                  `json:"enable_internal_emitter"`
-	LocketEnabled                bool                  `json:"locket_enabled"`
 	LocketSessionName            string                `json:"locket_session_name"`
 
 	lagerflags.LagerConfig

--- a/cmd/route-emitter/config/config_test.go
+++ b/cmd/route-emitter/config/config_test.go
@@ -57,7 +57,6 @@ var _ = Describe("Config", func() {
 				"client_cert_file": "/tmp/routing_api_client_cert_file",
 				"client_key_file": "/tmp/routing_api_client_key_file"
 			},
-			"locket_enabled": true,
 			"locket_address": "127.0.0.1:18018",
 			"locket_ca_cert_file": "locket-ca-cert",
 			"report_interval": "1m",
@@ -137,7 +136,6 @@ var _ = Describe("Config", func() {
 			EnableTCPEmitter:             true,
 			EnableInternalEmitter:        true,
 			RegisterDirectInstanceRoutes: true,
-			LocketEnabled:                true,
 			RoutingAPI: config.RoutingAPIConfig{
 				URL:            "https://routing-api.cf.service.internal",
 				Port:           443,

--- a/cmd/route-emitter/main.go
+++ b/cmd/route-emitter/main.go
@@ -149,7 +149,7 @@ func main() {
 		{Name: "unregistration", Runner: unregistrationSender},
 	}
 
-	if cfg.CellID == "" && cfg.LocketEnabled {
+	if cfg.CellID == "" {
 		locketClient, err := locket.NewClient(logger, cfg.ClientLocketConfig)
 		if err != nil {
 			logger.Fatal("failed-to-create-locket-client", err)

--- a/cmd/route-emitter/main_test.go
+++ b/cmd/route-emitter/main_test.go
@@ -1074,7 +1074,6 @@ var _ = Describe("Route Emitter", func() {
 			locketProcess = ginkgomon.Invoke(locketRunner)
 			cfgs = append(cfgs, func(cfg *config.RouteEmitterConfig) {
 				cfg.ClientLocketConfig = locketrunner.ClientLocketConfig()
-				cfg.LocketEnabled = true
 				cfg.LocketAddress = locketAddress
 			})
 		})


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: locks.locket.enabled - Diego release


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
